### PR TITLE
Fixed CI errors caused by -Depth 0

### DIFF
--- a/MultiTarget/GenerateAllProjectReferences.ps1
+++ b/MultiTarget/GenerateAllProjectReferences.ps1
@@ -14,7 +14,7 @@ Remove-Item -Path $projectPropsOutputDir -Recurse -Force -ErrorAction SilentlyCo
 New-Item -ItemType Directory -Force -Path $projectPropsOutputDir -ErrorAction SilentlyContinue | Out-Null;
 
 # Discover projects in provided paths
-foreach ($projectPath in Get-ChildItem -Directory -Depth 0 -Path "$PSScriptRoot/../../components/*") {
+foreach ($projectPath in Get-ChildItem -Directory -Path "$PSScriptRoot/../../components/*") {
   $srcPath = Resolve-Path "$($projectPath.FullName)\src";
   $srcProjectPath = Get-ChildItem -File "$srcPath\*.csproj";
 


### PR DESCRIPTION
This PR resolves [this issue](https://github.com/CommunityToolkit/Windows/actions/runs/4432135848/jobs/7787118495?pr=1). 

In PowerShell 5.1, the `-Depth 0` in `Get-ChildItem -Directory -Depth 0 -Path "$PSScriptRoot/../../components/*"` was causing it to grab directories 1 depth further than expected.