### PR TITLE
Fixed sample not picking up source-defined MultiTarget value, fixed compiler error

### DIFF
--- a/CommunityToolkit.Tooling.SampleGen/ToolkitSampleMetadataGenerator.Sample.cs
+++ b/CommunityToolkit.Tooling.SampleGen/ToolkitSampleMetadataGenerator.Sample.cs
@@ -163,10 +163,6 @@ public partial class ToolkitSampleMetadataGenerator : IIncrementalGenerator
 
     private static void CreateSampleRegistry(SourceProductionContext ctx, Dictionary<string, ToolkitSampleRecord> sampleMetadata)
     {
-        // TODO: Emit a better error that no samples are here?
-        if (sampleMetadata.Count == 0)
-            return;
-
         var source = BuildRegistrationCallsFromMetadata(sampleMetadata);
         ctx.AddSource($"ToolkitSampleRegistry.g.cs", source);
     }

--- a/MultiTarget/MultiTarget.props
+++ b/MultiTarget/MultiTarget.props
@@ -7,7 +7,7 @@
 
   <!-- If in a sample project, pull the MultiTarget settings from the source project. -->
   <!-- This behavior is also implemented in GeneratedAllProjectReferences.ps1 for <ProjectReference> generation. -->
-  <Import Project="../../src/MultiTarget.props" Condition="$(MultiTargetIsSampleProject) == 'true' AND !Exists('$(MSBuildProjectDirectory)\MultiTarget.props') AND Exists('../../src/MultiTarget.props') AND '$(MultiTarget)' == ''" />
+  <Import Project="$(MSBuildProjectDirectory)/../src/MultiTarget.props" Condition="$(MultiTargetIsSampleProject) == 'true' AND !Exists('$(MSBuildProjectDirectory)\MultiTarget.props') AND Exists('$(MSBuildProjectDirectory)/../src/MultiTarget.props') AND '$(MultiTarget)' == ''" />
   
   <Import Project="$(MSBuildThisFileDirectory)\Defaults.props" Condition="'$(MultiTarget)' == ''" />
 


### PR DESCRIPTION
This PR fixes:
- An issue where a MultiTarget value defined in a source project wasn't picked up by the sample project.
- A compiler error that occurs when the only component doesn't support all MultiTargets. 