### PR TITLE
Add Job to Build.yml to run Source Generator Tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,48 @@ jobs:
       - name: Check XAML Styling
         run: powershell -version 5.1 -command "./ApplyXamlStyling.ps1 -Passive" -ErrorAction Stop
 
+  test-tooling:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install .NET SDK v${{ env.DOTNET_VERSION }}
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: .NET Info (if diagnostics)
+        if: ${{ env.ENABLE_DIAGNOSTICS == 'true' }}
+        run: dotnet --info
+
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: dotnet build
+        working-directory: ./
+        run: dotnet build /bl CommunityToolkit.Tooling.sln
+
+      # Run tests
+      - name: Install Testspace Module
+        uses: testspace-com/setup-testspace@v1
+        with:
+          domain: ${{ github.repository_owner }}
+
+      - name: Run tests against Source Generators
+        run: dotnet test --logger "trx;LogFileName=sourceGeneratorTestResults.trx"
+
+      - name: Create test reports
+        run: |
+          testspace '[Source Generators]./**/TestResults/*.trx'
+        if: ${{ always() }}
+
+      - name: Artifact - Diagnostic Logs
+        uses: actions/upload-artifact@v3
+        if: ${{ (env.ENABLE_DIAGNOSTICS == 'true' || env.COREHOST_TRACE != '') && always() }}
+        with:
+          name: test-tooling-logs
+          path: ./**/*.*log
+
   # Test job to build the project template
   project-template:
     runs-on: windows-latest

--- a/.gitignore
+++ b/.gitignore
@@ -362,3 +362,4 @@ heads/
 
 # We use slngen to generate solutions
 *.sln
+!CommunityToolkit.Tooling.sln

--- a/CommunityToolkit.Tooling.SampleGen.Tests/CommunityToolkit.Tooling.SampleGen.Tests.csproj
+++ b/CommunityToolkit.Tooling.SampleGen.Tests/CommunityToolkit.Tooling.SampleGen.Tests.csproj
@@ -1,11 +1,16 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\GlobalUsings.cs" Link="GlobalUsings.cs" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" />

--- a/CommunityToolkit.Tooling.SampleGen/CommunityToolkit.Tooling.SampleGen.csproj
+++ b/CommunityToolkit.Tooling.SampleGen/CommunityToolkit.Tooling.SampleGen.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\GlobalUsings.cs" Link="GlobalUsings.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
   </ItemGroup>

--- a/CommunityToolkit.Tooling.SampleGen/ToolkitSampleMetadataGenerator.Sample.cs
+++ b/CommunityToolkit.Tooling.SampleGen/ToolkitSampleMetadataGenerator.Sample.cs
@@ -163,6 +163,10 @@ public partial class ToolkitSampleMetadataGenerator : IIncrementalGenerator
 
     private static void CreateSampleRegistry(SourceProductionContext ctx, Dictionary<string, ToolkitSampleRecord> sampleMetadata)
     {
+        // TODO: Emit a better error that no samples are here?
+        if (sampleMetadata.Count == 0)
+            return;
+
         var source = BuildRegistrationCallsFromMetadata(sampleMetadata);
         ctx.AddSource($"ToolkitSampleRegistry.g.cs", source);
     }

--- a/CommunityToolkit.Tooling.TestGen.Tests/CommunityToolkit.Tooling.TestGen.Tests.csproj
+++ b/CommunityToolkit.Tooling.TestGen.Tests/CommunityToolkit.Tooling.TestGen.Tests.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\GlobalUsings.cs" Link="GlobalUsings.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />

--- a/CommunityToolkit.Tooling.TestGen/CommunityToolkit.Tooling.TestGen.csproj
+++ b/CommunityToolkit.Tooling.TestGen/CommunityToolkit.Tooling.TestGen.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\GlobalUsings.cs" Link="GlobalUsings.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
   </ItemGroup>

--- a/CommunityToolkit.Tooling.XamlNamedPropertyRelay/CommunityToolkit.Tooling.XamlNamedPropertyRelay.csproj
+++ b/CommunityToolkit.Tooling.XamlNamedPropertyRelay/CommunityToolkit.Tooling.XamlNamedPropertyRelay.csproj
@@ -8,6 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\GlobalUsings.cs" Link="GlobalUsings.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.3" PrivateAssets="all" />
   </ItemGroup>

--- a/CommunityToolkit.Tooling.sln
+++ b/CommunityToolkit.Tooling.sln
@@ -1,0 +1,46 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CommunityToolkit.Tooling.SampleGen", "CommunityToolkit.Tooling.SampleGen\CommunityToolkit.Tooling.SampleGen.csproj", "{D1A78C19-61B6-416F-926F-F0520B16ECEF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CommunityToolkit.Tooling.SampleGen.Tests", "CommunityToolkit.Tooling.SampleGen.Tests\CommunityToolkit.Tooling.SampleGen.Tests.csproj", "{48B8DA1F-17D9-4425-A7D5-8CF078042727}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CommunityToolkit.Tooling.TestGen", "CommunityToolkit.Tooling.TestGen\CommunityToolkit.Tooling.TestGen.csproj", "{6101E286-908C-4D9E-87AB-5F4D36AF1BE2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CommunityToolkit.Tooling.TestGen.Tests", "CommunityToolkit.Tooling.TestGen.Tests\CommunityToolkit.Tooling.TestGen.Tests.csproj", "{FE42E6F5-6576-43C7-9A24-69CD93724D72}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CommunityToolkit.Tooling.XamlNamedPropertyRelay", "CommunityToolkit.Tooling.XamlNamedPropertyRelay\CommunityToolkit.Tooling.XamlNamedPropertyRelay.csproj", "{FE7981C9-6847-4A3F-A695-FB2A0A4C9B9A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D1A78C19-61B6-416F-926F-F0520B16ECEF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D1A78C19-61B6-416F-926F-F0520B16ECEF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D1A78C19-61B6-416F-926F-F0520B16ECEF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D1A78C19-61B6-416F-926F-F0520B16ECEF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{48B8DA1F-17D9-4425-A7D5-8CF078042727}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{48B8DA1F-17D9-4425-A7D5-8CF078042727}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{48B8DA1F-17D9-4425-A7D5-8CF078042727}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{48B8DA1F-17D9-4425-A7D5-8CF078042727}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6101E286-908C-4D9E-87AB-5F4D36AF1BE2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6101E286-908C-4D9E-87AB-5F4D36AF1BE2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6101E286-908C-4D9E-87AB-5F4D36AF1BE2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6101E286-908C-4D9E-87AB-5F4D36AF1BE2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FE42E6F5-6576-43C7-9A24-69CD93724D72}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FE42E6F5-6576-43C7-9A24-69CD93724D72}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FE42E6F5-6576-43C7-9A24-69CD93724D72}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FE42E6F5-6576-43C7-9A24-69CD93724D72}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FE7981C9-6847-4A3F-A695-FB2A0A4C9B9A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FE7981C9-6847-4A3F-A695-FB2A0A4C9B9A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FE7981C9-6847-4A3F-A695-FB2A0A4C9B9A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FE7981C9-6847-4A3F-A695-FB2A0A4C9B9A}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Fixes #30

As part of our initial migration here, we missed that the Source Generators were being tested as part of the main build pipeline of the Labs repo, which wasn't copied here as it wasn't as tooling specific only.

This PR adds a new independent job which runs on `linux` and pulls the repo, builds just the SG tooling projects, and then run tests against them and reports to our testspaces module.

Note: need to check the path outputs of the test files and how that gets reported...