### PR TITLE
Fixed generated option pane attributes being incorrectly pruned

### DIFF
--- a/CommunityToolkit.Tooling.SampleGen/ToolkitSampleMetadataGenerator.Sample.cs
+++ b/CommunityToolkit.Tooling.SampleGen/ToolkitSampleMetadataGenerator.Sample.cs
@@ -116,7 +116,7 @@ public partial class ToolkitSampleMetadataGenerator : IIncrementalGenerator
             {
                 var toolkitSampleAttributeData = data.Left.Left.Left.Right.Where(x => x != default).Distinct();
                 var optionsPaneAttribute = data.Left.Left.Left.Left.Where(x => x != default).Distinct();
-                var generatedOptionPropertyData = data.Left.Left.Right.Where(x => x != default).Distinct();
+                var generatedOptionPropertyData = data.Left.Left.Right.Where(x => x != default);
                 var markdownFileData = data.Left.Right.Where(x => x != default).Distinct();
                 var currentAssembly = data.Right;
 


### PR DESCRIPTION
This PR is a small change that closes #20.