### PR TITLE
Ensure `<NoWarn>` blocks in props/proj files don't conflict and overwrite one another

### DIFF
--- a/MultiTarget/MultiTarget.props
+++ b/MultiTarget/MultiTarget.props
@@ -40,7 +40,7 @@
 
   <PropertyGroup>
     <!-- These suppressions are for references between generated assemblies and that VS can keep in the Error List once resolved -->
-    <NoWarn>WMC1006;CS8034;</NoWarn>
+    <NoWarn>$(NoWarn);WMC1006;CS8034;</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MultiTarget/Uno.props
+++ b/MultiTarget/Uno.props
@@ -22,7 +22,7 @@
     </ItemGroup>
     <PropertyGroup Condition="'$(IsWpfHead)' == 'true'">
         <!-- Ignorable issue from SkiaSharp package, see: https://github.com/CommunityToolkit/Labs-Windows/pull/119#issuecomment-1125373091 -->
-        <NoWarn>NU1701</NoWarn>
+        <NoWarn>$(NoWarn);NU1701</NoWarn>
     </PropertyGroup>
 
     <ItemGroup Condition="'$(IsWasmHead)' == 'true'">

--- a/ProjectHeads/Head.Uwp.props
+++ b/ProjectHeads/Head.Uwp.props
@@ -17,6 +17,7 @@
         <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
         <WindowsXamlEnableOverview>true</WindowsXamlEnableOverview>
         <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
+        <NoWarn>$(NoWarn);2008</NoWarn>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)' == 'Release'">
@@ -26,8 +27,7 @@
     <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
         <DebugSymbols>true</DebugSymbols>
         <OutputPath>bin\x86\Debug\</OutputPath>
-        <DefineConstants>$(DefineConstants);DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
-        <NoWarn>;2008</NoWarn>
+        <DefineConstants>$(DefineConstants);DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>        
         <DebugType>full</DebugType>
         <PlatformTarget>x86</PlatformTarget>
         <UseVSHostingProcess>false</UseVSHostingProcess>
@@ -39,7 +39,6 @@
         <OutputPath>bin\x86\Release\</OutputPath>
         <DefineConstants>$(DefineConstants);TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
         <Optimize>true</Optimize>
-        <NoWarn>;2008</NoWarn>
         <DebugType>pdbonly</DebugType>
         <PlatformTarget>x86</PlatformTarget>
         <UseVSHostingProcess>false</UseVSHostingProcess>
@@ -51,7 +50,6 @@
         <DebugSymbols>true</DebugSymbols>
         <OutputPath>bin\ARM\Debug\</OutputPath>
         <DefineConstants>$(DefineConstants);DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
-        <NoWarn>;2008</NoWarn>
         <DebugType>full</DebugType>
         <PlatformTarget>ARM</PlatformTarget>
         <UseVSHostingProcess>false</UseVSHostingProcess>
@@ -63,7 +61,6 @@
         <OutputPath>bin\ARM\Release\</OutputPath>
         <DefineConstants>$(DefineConstants);TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
         <Optimize>true</Optimize>
-        <NoWarn>;2008</NoWarn>
         <DebugType>pdbonly</DebugType>
         <PlatformTarget>ARM</PlatformTarget>
         <UseVSHostingProcess>false</UseVSHostingProcess>
@@ -75,7 +72,6 @@
         <DebugSymbols>true</DebugSymbols>
         <OutputPath>bin\ARM64\Debug\</OutputPath>
         <DefineConstants>$(DefineConstants);DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
-        <NoWarn>;2008</NoWarn>
         <DebugType>full</DebugType>
         <PlatformTarget>ARM64</PlatformTarget>
         <UseVSHostingProcess>false</UseVSHostingProcess>
@@ -87,7 +83,6 @@
         <OutputPath>bin\ARM64\Release\</OutputPath>
         <DefineConstants>$(DefineConstants);TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
         <Optimize>true</Optimize>
-        <NoWarn>;2008</NoWarn>
         <DebugType>pdbonly</DebugType>
         <PlatformTarget>ARM64</PlatformTarget>
         <UseVSHostingProcess>false</UseVSHostingProcess>
@@ -99,7 +94,6 @@
         <DebugSymbols>true</DebugSymbols>
         <OutputPath>bin\x64\Debug\</OutputPath>
         <DefineConstants>$(DefineConstants);DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
-        <NoWarn>;2008</NoWarn>
         <DebugType>full</DebugType>
         <PlatformTarget>x64</PlatformTarget>
         <UseVSHostingProcess>false</UseVSHostingProcess>
@@ -111,7 +105,6 @@
         <OutputPath>bin\x64\Release\</OutputPath>
         <DefineConstants>$(DefineConstants);TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
         <Optimize>true</Optimize>
-        <NoWarn>;2008</NoWarn>
         <DebugType>pdbonly</DebugType>
         <PlatformTarget>x64</PlatformTarget>
         <UseVSHostingProcess>false</UseVSHostingProcess>


### PR DESCRIPTION
Consolidates the UWP NoWarn block as well

Needed for https://github.com/CommunityToolkit/Labs-Windows/pull/354