### PR TITLE
Update to WindowsAppSDK 1.3.230331000

### DIFF
--- a/GlobalUsings_Tests.cs
+++ b/GlobalUsings_Tests.cs
@@ -5,6 +5,9 @@
 // This file contains directives available in test projects.
 // Learn more global using directives at https://docs.microsoft.com/dotnet/csharp/language-reference/keywords/using-directive#global-modifier
 
+global using CommunityToolkit.Tests.Internal; // TODO: For CompositionTargetHelper until ported over into package.
+global using CommunityToolkit.WinUI;
+
 #if !WINAPPSDK
 global using Windows.UI;
 global using Windows.UI.Core;

--- a/MultiTarget/MultiTarget.props
+++ b/MultiTarget/MultiTarget.props
@@ -45,7 +45,7 @@
 
   <ItemGroup>
     <PackageReference Condition="'$(TargetFramework)' == '$(UwpTargetFramework)'" Include="Microsoft.UI.Xaml" Version="2.7.0" />
-    <PackageReference Condition="'$(TargetFramework)' == '$(WinAppSdkTargetFramework)'" Include="Microsoft.WindowsAppSDK" Version="1.2.230118.102" />
+    <PackageReference Condition="'$(TargetFramework)' == '$(WinAppSdkTargetFramework)'" Include="Microsoft.WindowsAppSDK" Version="1.3.230331000" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ProjectHeads/Head.WinAppSdk.props
+++ b/ProjectHeads/Head.WinAppSdk.props
@@ -15,8 +15,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.230118.102" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230331000" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
 </Project>

--- a/ProjectTemplate/tests/ExampleProjectTemplateTestClass.cs
+++ b/ProjectTemplate/tests/ExampleProjectTemplateTestClass.cs
@@ -4,8 +4,6 @@
 
 using CommunityToolkit.Tooling.TestGen;
 using CommunityToolkit.Tests;
-using CommunityToolkit.Tests.Internal; // TODO: For CompositionTargetHelper until ported over into package.
-using CommunityToolkit.WinUI;
 using CommunityToolkit.WinUI.Controls;
 
 namespace ProjectTemplateExperiment.Tests;


### PR DESCRIPTION
Update Microsoft.Windows.SDK.BuildTools to 10.0.22621.756

Needed for SizerBase controls to resolve platform issue with Manipulation Events (which was probably going to be needed for the test injector work we need to finish as well), so bumping this to new min version for WASDK.

1.0 is out-of-support, and 1.1 is out-of-support in a month https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/release-channels#release-lifecycle

So, keeping up-to-date is probably just going to be the new norm for us anyway.