### PR TITLE
Add C# language polyfills to UWP heads

### DIFF
--- a/ProjectHeads/Head.Uwp.props
+++ b/ProjectHeads/Head.Uwp.props
@@ -27,7 +27,7 @@
     <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
         <DebugSymbols>true</DebugSymbols>
         <OutputPath>bin\x86\Debug\</OutputPath>
-        <DefineConstants>$(DefineConstants);DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>        
+        <DefineConstants>$(DefineConstants);DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
         <DebugType>full</DebugType>
         <PlatformTarget>x86</PlatformTarget>
         <UseVSHostingProcess>false</UseVSHostingProcess>
@@ -122,6 +122,10 @@
         </PackageReference>
         <PackageReference Include="Microsoft.UI.Xaml">
             <Version>2.7.0</Version>
+        </PackageReference>
+        <PackageReference Include="PolySharp" Version="1.13.1">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
     </ItemGroup>
 


### PR DESCRIPTION
This PR adds PolySharp to UWP heads (tests, app) to fix errors we've seen while porting code caused by missing language features.