### PR TITLE
Suppress warnings for IDisposable exposed by Uno 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,6 +147,13 @@ jobs:
       TEST_PROJECT_DIRECTORY: components/CiTestExp
 
     steps:
+      - name: Configure Pagefile
+        uses: al-cheb/configure-pagefile-action@v1.2
+        with:
+          minimum-size: 32GB
+          maximum-size: 32GB
+          disk-root: "C:"
+          
       - name: Install .NET SDK v${{ env.DOTNET_VERSION }}
         uses: actions/setup-dotnet@v3
         with:

--- a/MultiTarget/Uno.props
+++ b/MultiTarget/Uno.props
@@ -31,7 +31,7 @@
             Uno uses IDisposable internally, but exposes it publicly.
             See https://github.com/CommunityToolkit/Labs-Windows/pull/275#issuecomment-1331113635
          -->
-        <NoWarn>$(NoWarn);CA1063</NoWarn>
+        <NoWarn>$(NoWarn);CA1063;CA1001;</NoWarn>
     </PropertyGroup>
 
     <ItemGroup Condition="'$(IsWasmHead)' == 'true'">

--- a/MultiTarget/Uno.props
+++ b/MultiTarget/Uno.props
@@ -4,7 +4,7 @@
     <ItemGroup Condition="'$(IsUno)' == 'true'">
         <PackageReference Include="Uno.UI" Version="4.6.18" />
     </ItemGroup>
-    
+
     <PropertyGroup Condition="'$(IsUno)' == 'true'">
         <UnoUIUseRoslynSourceGenerators>true</UnoUIUseRoslynSourceGenerators>
     </PropertyGroup>
@@ -20,9 +20,18 @@
     <ItemGroup Condition="'$(IsWpfHead)' == 'true'">
         <PackageReference Include="Uno.UI.Skia.Wpf" Version="4.6.18" />
     </ItemGroup>
+
     <PropertyGroup Condition="'$(IsWpfHead)' == 'true'">
         <!-- Ignorable issue from SkiaSharp package, see: https://github.com/CommunityToolkit/Labs-Windows/pull/119#issuecomment-1125373091 -->
         <NoWarn>$(NoWarn);NU1701</NoWarn>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <!--
+            Uno uses IDisposable internally, but exposes it publicly.
+            See https://github.com/CommunityToolkit/Labs-Windows/pull/275#issuecomment-1331113635
+         -->
+        <NoWarn>$(NoWarn);CA1063</NoWarn>
     </PropertyGroup>
 
     <ItemGroup Condition="'$(IsWasmHead)' == 'true'">


### PR DESCRIPTION
This issue originally appeared during creation of the MarqueeText control: https://github.com/CommunityToolkit/Labs-Windows/pull/275#issuecomment-1331113635, and has appeared in several more controls since. 

In https://github.com/CommunityToolkit/Labs-Windows/pull/377#issuecomment-1452405722, we moved to use this as a workaround until the issue can be solved on the Uno side.