### PR TITLE
Made WinUI 2.x optional on uwp

### DIFF
--- a/MultiTarget/MultiTargetIdentifiers.props
+++ b/MultiTarget/MultiTargetIdentifiers.props
@@ -50,7 +50,7 @@
 
     <IsUno Condition="'$(IsWasm)' == 'true' OR '$(IsWpf)' == 'true' OR '$(IsGtk)' == 'true' OR '$(IsDroid)' == 'true' OR '$(IsMacOS)' == 'true' OR '$(IsiOS)' == 'true'">true</IsUno>
 
-    <HasWinUI Condition="'$(HasWinUI)' == '' AND '$(IsUwp)' == 'true' OR '$(IsWinAppSdk)' == 'true' OR '$(IsUno)' == 'true'">true</HasWinUI>
+    <HasWinUI Condition="'$(HasWinUI)' == '' AND ('$(IsUwp)' == 'true' OR '$(IsWinAppSdk)' == 'true' OR '$(IsUno)' == 'true')">true</HasWinUI>
 
     <!--
       This property is only for changing the version used by Uno.

--- a/MultiTarget/MultiTargetIdentifiers.props
+++ b/MultiTarget/MultiTargetIdentifiers.props
@@ -46,17 +46,17 @@
     <IsDroid Condition="'$(IsDroid)' == '' AND '$(TargetFramework)' == '$(AndroidLibTargetFramework)' AND '$(AndroidLibTargetFramework)' != '' AND '$(MultiTargetsDroid)' == 'true'">true</IsDroid>
     <IsMacOS Condition="'$(IsMacOS)' == '' AND '$(TargetFramework)' == '$(MacOSLibTargetFramework)' AND '$(MacOSLibTargetFramework)' != '' AND '$(MultiTargetsMacOS)' == 'true'">true</IsMacOS>
     <IsiOS Condition="'$(IsiOS)' == '' AND '$(TargetFramework)' == '$(iOSLibTargetFramework)' AND '$(iOSLibTargetFramework)' != '' AND '$(MultiTargetsiOS)' == 'true'">true</IsiOS>
-    <IsNetstandard Condition="'$(IsNetstandard)' == '' AND $(MultiTargetsNetstandard) == 'true'">true</IsNetstandard>
+    <IsNetstandard Condition="'$(IsNetstandard)' == '' AND '$(TargetFramework)' == '$(NetStandardCommonTargetFramework)' AND '$(MultiTargetsNetstandard)' == 'true'">true</IsNetstandard>
 
     <IsUno Condition="'$(IsWasm)' == 'true' OR '$(IsWpf)' == 'true' OR '$(IsGtk)' == 'true' OR '$(IsDroid)' == 'true' OR '$(IsMacOS)' == 'true' OR '$(IsiOS)' == 'true'">true</IsUno>
 
-    <HasWinUI Condition="'$(IsUwp)' == 'true' OR '$(IsWinAppSdk)' == 'true' OR '$(IsUno)' == 'true'">true</HasWinUI>
+    <HasWinUI Condition="'$(HasWinUI)' == '' AND '$(IsUwp)' == 'true' OR '$(IsWinAppSdk)' == 'true' OR '$(IsUno)' == 'true'">true</HasWinUI>
 
     <!--
       This property is only for changing the version used by Uno.
       Force the version to 2 for UWP and 3 for WinAppSDK.
      -->
-    <WinUIMajorVersion Condition="'$(IsUwp)' == 'true'">2</WinUIMajorVersion>
-    <WinUIMajorVersion Condition="'$(IsWinAppSdk)' == 'true'">3</WinUIMajorVersion>
+    <WinUIMajorVersion Condition="'$(HasWinUI)' == 'true' AND '$(IsUwp)' == 'true'">2</WinUIMajorVersion>
+    <WinUIMajorVersion Condition="'$(HasWinUI)' == 'true' AND '$(IsWinAppSdk)' == 'true'">3</WinUIMajorVersion>
   </PropertyGroup>
 </Project>

--- a/MultiTarget/PackageReferences/Uwp.props
+++ b/MultiTarget/PackageReferences/Uwp.props
@@ -1,6 +1,6 @@
 <Project>
   <ItemGroup>
-    <PackageReference Include="Microsoft.UI.Xaml" Version="2.7.0" />
+    <PackageReference Condition="'$(HasWinUI)' == 'true'" Include="Microsoft.UI.Xaml" Version="2.7.0" />
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Closes #58 

This PR makes use of the existing `HasWinUI` property. When in a library, this property can be set to 'false' to override the default. On UWP, this will prevent `Microsoft.Xaml.UI` from being included.