### PR TITLE
Gallery improvements

### DIFF
--- a/CommunityToolkit.App.Shared/Renderers/ToolkitDocumentationRenderer.xaml
+++ b/CommunityToolkit.App.Shared/Renderers/ToolkitDocumentationRenderer.xaml
@@ -12,7 +12,7 @@
       xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
       xmlns:renderer="using:CommunityToolkit.App.Shared.Renderers"
       xmlns:wasm="http://uno.ui/wasm"
-      xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:converters="using:CommunityToolkit.WinUI.Converters"
       mc:Ignorable="d wasm">
 
     <Page.Resources>
@@ -34,6 +34,7 @@
         <local:DocOrSampleTemplateSelector x:Key="DocOrSampleTemplateSelector"
                                            Document="{StaticResource DocumentTemplate}"
                                            Sample="{StaticResource SampleTemplate}" />
+        <converters:DoubleToVisibilityConverter x:Name="doubleToVisibilityConverter" GreaterThan="1" TrueValue="Visible" FalseValue="Collapsed" NullValue="Collapsed"/>
     </Page.Resources>
 
     <Grid>
@@ -90,7 +91,12 @@
         <!--  Header grid  -->
         <Grid x:Name="HeaderGrid"
               Margin="40,24,40,40"
-              VerticalAlignment="Top">
+              VerticalAlignment="Top"
+              ColumnSpacing="8">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
@@ -109,75 +115,75 @@
                        Text="{x:Bind Metadata.Description, Mode=OneWay}"
                        TextWrapping="WrapWholeWords" />
 
-            <Grid Grid.Row="2"
-                  Margin="0,16,0,0"
-                  ColumnSpacing="8">
-
-                <StackPanel x:Name="ButtonPanel"
-                            x:Load="{x:Bind renderer:ToolkitDocumentationRenderer.IsProjectPathValid()}"
-                            Orientation="Horizontal"
-                            Spacing="8">
-                    <Button Visibility="{x:Bind renderer:ToolkitDocumentationRenderer.IsIdValid(Metadata.DiscussionId), Mode=OneWay}">
-                        <StackPanel Orientation="Horizontal">
-                            <FontIcon FontSize="14"
-                                      Glyph="&#xE8F2;" />
-                            <TextBlock Margin="8,0,0,0"
-                                       Text="Discussion" />
-                        </StackPanel>
-                        <interactivity:Interaction.Behaviors>
-                            <interactions:EventTriggerBehavior EventName="Click">
-                                <behaviors:NavigateToUriAction NavigateUri="{x:Bind renderer:ToolkitDocumentationRenderer.ToGitHubUri('discussions', Metadata.DiscussionId), Mode=OneWay}" />
-                            </interactions:EventTriggerBehavior>
-                        </interactivity:Interaction.Behaviors>
-                    </Button>
-                    <Button Visibility="{x:Bind renderer:ToolkitDocumentationRenderer.IsIdValid(Metadata.IssueId), Mode=OneWay}">
-                        <StackPanel Orientation="Horizontal">
-                            <PathIcon Margin="-3"
-                                      VerticalAlignment="Center"
-                                      Data="{StaticResource GithubIcon}">
-                                <PathIcon.RenderTransform>
-                                    <CompositeTransform ScaleX="0.65"
-                                                        ScaleY="0.65"
-                                                        TranslateX="-5"
-                                                        TranslateY="5" />
-                                </PathIcon.RenderTransform>
-                            </PathIcon>
-                            <TextBlock Margin="-4,0,0,0"
-                                       Text="Tracking Issue" />
-                        </StackPanel>
-                        <interactivity:Interaction.Behaviors>
-                            <interactions:EventTriggerBehavior EventName="Click">
-                                <behaviors:NavigateToUriAction NavigateUri="{x:Bind renderer:ToolkitDocumentationRenderer.ToGitHubUri('issues', Metadata.IssueId), Mode=OneWay}" />
-                            </interactions:EventTriggerBehavior>
-                        </interactivity:Interaction.Behaviors>
-                    </Button>
-                </StackPanel>
-
-                <StackPanel HorizontalAlignment="Right"
-                            VerticalAlignment="Center"
-                            Orientation="Horizontal"
-                            Spacing="8">
-                    <TextBlock VerticalAlignment="Center"
+            <StackPanel x:Name="ButtonPanel"
+                        Grid.Row="2"
+                        Margin="0,16,0,0"
+                        x:Load="{x:Bind renderer:ToolkitDocumentationRenderer.IsProjectPathValid()}"
+                        Orientation="Horizontal"
+                        Spacing="8">
+                <Button Visibility="{x:Bind renderer:ToolkitDocumentationRenderer.IsIdValid(Metadata.DiscussionId), Mode=OneWay}">
+                    <StackPanel Orientation="Horizontal">
+                        <FontIcon FontSize="14"
+                                  Glyph="&#xE8F2;" />
+                        <TextBlock Margin="8,0,0,0"
+                                   Text="Discussion" />
+                    </StackPanel>
+                    <interactivity:Interaction.Behaviors>
+                        <interactions:EventTriggerBehavior EventName="Click">
+                            <behaviors:NavigateToUriAction NavigateUri="{x:Bind renderer:ToolkitDocumentationRenderer.ToGitHubUri('discussions', Metadata.DiscussionId), Mode=OneWay}" />
+                        </interactions:EventTriggerBehavior>
+                    </interactivity:Interaction.Behaviors>
+                </Button>
+                <Button Visibility="{x:Bind renderer:ToolkitDocumentationRenderer.IsIdValid(Metadata.IssueId), Mode=OneWay}">
+                    <StackPanel Orientation="Horizontal">
+                        <PathIcon Margin="-3"
+                                  VerticalAlignment="Center"
+                                  Data="{StaticResource GithubIcon}">
+                            <PathIcon.RenderTransform>
+                                <CompositeTransform ScaleX="0.65"
+                                                    ScaleY="0.65"
+                                                    TranslateX="-5"
+                                                    TranslateY="5" />
+                            </PathIcon.RenderTransform>
+                        </PathIcon>
+                        <TextBlock Margin="-4,0,0,0"
+                                   Text="Tracking Issue" />
+                    </StackPanel>
+                    <interactivity:Interaction.Behaviors>
+                        <interactions:EventTriggerBehavior EventName="Click">
+                            <behaviors:NavigateToUriAction NavigateUri="{x:Bind renderer:ToolkitDocumentationRenderer.ToGitHubUri('issues', Metadata.IssueId), Mode=OneWay}" />
+                        </interactions:EventTriggerBehavior>
+                    </interactivity:Interaction.Behaviors>
+                </Button>
+            </StackPanel>
+            <ComboBox x:Name="SampleSelectionBox"
+                      Grid.RowSpan="2"
+                      Grid.Column="1"
+                      MinWidth="160"
+                      HorizontalAlignment="Right"
+                      VerticalAlignment="Bottom"
+                      Visibility="{x:Bind Samples.Count, Converter={StaticResource doubleToVisibilityConverter}}"
+                      ItemsSource="{x:Bind Samples, Mode=OneWay}"
+                      SelectedIndex="0"
+                      SelectionChanged="SampleSelectionBox_SelectionChanged">
+                <ComboBox.Header>
+                    <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                Style="{StaticResource CaptionTextBlockStyle}"
-                               Text="Sample:" />
-                    <ComboBox x:Name="SampleSelectionBox"
-                              MinWidth="160"
-                              ItemsSource="{x:Bind Samples, Mode=OneWay}"
-                              SelectedIndex="0"
-                              SelectionChanged="SampleSelectionBox_SelectionChanged">
-                        <ComboBox.ItemTemplate>
-                            <DataTemplate x:DataType="metadata:ToolkitSampleMetadata">
-                                <TextBlock Text="{Binding DisplayName, Mode=OneWay}" />
-                            </DataTemplate>
-                        </ComboBox.ItemTemplate>
-                    </ComboBox>
-                </StackPanel>
-            </Grid>
+                               Text="Go to sample:" />
+                </ComboBox.Header>
+                <ComboBox.ItemTemplate>
+                    <DataTemplate x:DataType="metadata:ToolkitSampleMetadata">
+                        <TextBlock Text="{Binding DisplayName, Mode=OneWay}" />
+                    </DataTemplate>
+                </ComboBox.ItemTemplate>
+            </ComboBox>
+
             <muxc:InfoBar Title="Experimental"
                           Grid.Row="3"
+                          Grid.ColumnSpan="2"
                           Margin="0,16,0,0"
                           IsClosable="False"
-                          IsOpen="True">
+                          IsOpen="False">
                 <muxc:InfoBar.ActionButton>
                     <HyperlinkButton Content="Learn how you can use this experiment in your app"
                                      NavigateUri="https://aka.ms/wct/wiki/previewpackages" />

--- a/CommunityToolkit.App.Shared/Renderers/ToolkitDocumentationRenderer.xaml
+++ b/CommunityToolkit.App.Shared/Renderers/ToolkitDocumentationRenderer.xaml
@@ -3,6 +3,7 @@
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
       xmlns:behaviors="using:CommunityToolkit.App.Shared.Behaviors"
+      xmlns:converters="using:CommunityToolkit.WinUI.Converters"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:interactions="using:Microsoft.Xaml.Interactions.Core"
       xmlns:interactivity="using:Microsoft.Xaml.Interactivity"
@@ -12,7 +13,7 @@
       xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
       xmlns:renderer="using:CommunityToolkit.App.Shared.Renderers"
       xmlns:wasm="http://uno.ui/wasm"
-      xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:converters="using:CommunityToolkit.WinUI.Converters"
+      xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       mc:Ignorable="d wasm">
 
     <Page.Resources>
@@ -34,7 +35,11 @@
         <local:DocOrSampleTemplateSelector x:Key="DocOrSampleTemplateSelector"
                                            Document="{StaticResource DocumentTemplate}"
                                            Sample="{StaticResource SampleTemplate}" />
-        <converters:DoubleToVisibilityConverter x:Name="doubleToVisibilityConverter" GreaterThan="1" TrueValue="Visible" FalseValue="Collapsed" NullValue="Collapsed"/>
+        <converters:DoubleToVisibilityConverter x:Name="doubleToVisibilityConverter"
+                                                FalseValue="Collapsed"
+                                                GreaterThan="1"
+                                                NullValue="Collapsed"
+                                                TrueValue="Visible" />
     </Page.Resources>
 
     <Grid>
@@ -90,7 +95,7 @@
 
         <!--  Header grid  -->
         <Grid x:Name="HeaderGrid"
-              Margin="40,24,40,40"
+              Margin="40,24,40,24"
               VerticalAlignment="Top"
               ColumnSpacing="8">
             <Grid.ColumnDefinitions>
@@ -112,6 +117,7 @@
             <TextBlock Grid.Row="1"
                        Margin="0,8,0,0"
                        HorizontalAlignment="Left"
+                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                        Text="{x:Bind Metadata.Description, Mode=OneWay}"
                        TextWrapping="WrapWholeWords" />
 
@@ -162,10 +168,10 @@
                       MinWidth="160"
                       HorizontalAlignment="Right"
                       VerticalAlignment="Bottom"
-                      Visibility="{x:Bind Samples.Count, Converter={StaticResource doubleToVisibilityConverter}}"
                       ItemsSource="{x:Bind Samples, Mode=OneWay}"
                       SelectedIndex="0"
-                      SelectionChanged="SampleSelectionBox_SelectionChanged">
+                      SelectionChanged="SampleSelectionBox_SelectionChanged"
+                      Visibility="{x:Bind Samples.Count, Converter={StaticResource doubleToVisibilityConverter}}">
                 <ComboBox.Header>
                     <TextBlock Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                Style="{StaticResource CaptionTextBlockStyle}"
@@ -183,7 +189,7 @@
                           Grid.ColumnSpan="2"
                           Margin="0,16,0,0"
                           IsClosable="False"
-                          IsOpen="False">
+                          Visibility="Collapsed">
                 <muxc:InfoBar.ActionButton>
                     <HyperlinkButton Content="Learn how you can use this experiment in your app"
                                      NavigateUri="https://aka.ms/wct/wiki/previewpackages" />
@@ -192,3 +198,4 @@
         </Grid>
     </Grid>
 </Page>
+

--- a/CommunityToolkit.App.Shared/Renderers/ToolkitSampleRenderer.xaml
+++ b/CommunityToolkit.App.Shared/Renderers/ToolkitSampleRenderer.xaml
@@ -97,9 +97,10 @@
                 <ScrollViewer x:Name="OptionsScrollViewer"
                               Grid.Row="0"
                               Grid.Column="0"
-                              MinWidth="256"
+                              MinWidth="286"
                               Padding="16">
                     <ContentControl x:Name="OptionsControl"
+                                    HorizontalContentAlignment="Stretch"
                                     Content="{x:Bind SampleOptionsPaneInstance, Mode=OneWay}" />
                 </ScrollViewer>
                 <Grid x:Name="FixedOptionsBar"

--- a/ProjectHeads/App.Head.Uno.UI.Dependencies.props
+++ b/ProjectHeads/App.Head.Uno.UI.Dependencies.props
@@ -4,5 +4,8 @@
     <ItemGroup>
         <!--<PackageReference Include="Uno.Microsoft.Toolkit.Uwp.UI.Controls.Markdown" Version="7.1.11" />-->
         <PackageReference Include="Uno.Microsoft.Xaml.Behaviors.Uwp.Managed" Version="2.3.1-uno.2" />
+	<PackageReference Include="CommunityToolkit.Uwp.Converters" Version="8.0.0-beta.1" />
     </ItemGroup>
 </Project>
+
+

--- a/ProjectHeads/App.Head.Uno.WinUI.Dependencies.props
+++ b/ProjectHeads/App.Head.Uno.WinUI.Dependencies.props
@@ -4,5 +4,6 @@
     <ItemGroup>
         <!--<PackageReference Include="Uno.CommunityToolkit.WinUI.UI.Controls.Markdown" Version="7.1.100-dev.15.g12261e2626" />-->
         <PackageReference Include="Uno.Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.3.1-uno.2" />
+        <PackageReference Include="CommunityToolkit.WinUI.Converters" Version="8.0.0-beta.1" />
     </ItemGroup>
 </Project>

--- a/ProjectHeads/App.Head.Uwp.Dependencies.props
+++ b/ProjectHeads/App.Head.Uwp.Dependencies.props
@@ -5,5 +5,6 @@
         <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls.Markdown" Version="7.1.2" />
         <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed" Version="2.0.1" />
         <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+        <PackageReference Include="CommunityToolkit.Uwp.Converters" Version="8.0.0-beta.1" />
     </ItemGroup>
 </Project>

--- a/ProjectHeads/App.Head.WinAppSdk.Dependencies.props
+++ b/ProjectHeads/App.Head.WinAppSdk.Dependencies.props
@@ -4,5 +4,6 @@
     <ItemGroup>
         <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.Markdown" Version="7.1.2" />
         <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.0.9" />
+        <PackageReference Include="CommunityToolkit.WinUI.Converters" Version="8.0.0-beta.1" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
- **Settings stretch horizontally now**, resolving: https://github.com/CommunityToolkit/Tooling-Windows-Submodule/issues/90

Before:
![image](https://github.com/CommunityToolkit/Tooling-Windows-Submodule/assets/9866362/33d79878-3380-4157-a81d-676a057122a0)


After:
![image](https://github.com/CommunityToolkit/Tooling-Windows-Submodule/assets/9866362/8ecbf48a-65b9-483c-8bd9-e5bcca2c5469)

- **Hiding the Experimental bar for now**

- Hiding samples dropdown if there's only 1 sample, resolving: https://github.com/CommunityToolkit/Tooling-Windows-Submodule/issues/86