### PR TITLE
Fix issue where Rename-Item would fail when generating solution with PowerShell script

### DIFF
--- a/ProjectHeads/GenerateSingleSampleHeads.ps1
+++ b/ProjectHeads/GenerateSingleSampleHeads.ps1
@@ -52,10 +52,8 @@ dotnet new --install "$PSScriptRoot/SingleComponent" --force
 Push-Location $componentPath
 
 # Copy and rename projects
-dotnet new ct-tooling-heads -n $componentName
-
-# Rename folder from component name (dotnet tooling default) to 'heads'
-Rename-Item -Path "$componentName" -NewName $headsFolderName -Force
+# Set output folder to 'heads' instead of default
+dotnet new ct-tooling-heads -n $componentName -o $headsFolderName
 
 # Remove template, as just for script
 dotnet new --uninstall "$PSScriptRoot/SingleComponent"


### PR DESCRIPTION
This would cause the 'heads' directory to not be named properly and cause subtle issues that would be unnoticed. This should be more resilient now and not prone to problems and conflicts with file handles. End behavior is exactly the same.

This change just removes the error-prone `Rename-Item` powershell step to instead use the output flag on the `dotnet new` command, end output/behavior is the same, so no functional change.

Just increased stability without a random unseen thing going on behind the scenes which causes random issues elsewhere! 🎉