### PR TITLE
Enable reusing ToolkitSampleOptionsPane across samples

### DIFF
--- a/CommunityToolkit.Tooling.SampleGen/Attributes/ToolkitSampleOptionsPaneAttribute.cs
+++ b/CommunityToolkit.Tooling.SampleGen/Attributes/ToolkitSampleOptionsPaneAttribute.cs
@@ -7,7 +7,7 @@ namespace CommunityToolkit.Tooling.SampleGen.Attributes;
 /// <summary>
 /// Registers a control as the options panel for a toolkit sample.
 /// </summary>
-[AttributeUsage(AttributeTargets.Class)]
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
 public sealed class ToolkitSampleOptionsPaneAttribute : Attribute
 {
     /// <summary>


### PR DESCRIPTION
Hotfix that enables reusing a single `ToolkitSampleOptionsPane` for multiple samples. Needed for https://github.com/CommunityToolkit/Windows/issues/124.

