### PR TITLE
Fixed an issue building sample projects on macOS

### DIFF
--- a/ToolkitComponent.SampleProject.props
+++ b/ToolkitComponent.SampleProject.props
@@ -9,7 +9,7 @@
   <!-- Import this component's source project -->
   <ItemGroup>
     <ProjectReference Include="$(MSBuildProjectDirectory)\..\src\*.csproj" />
-    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
+    <PackageReference Condition="'$(IsMacOS)' != 'true'" Include="System.Collections.Immutable" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This is a fix for a bug was that introduced in https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/61 and found during investigation of https://github.com/CommunityToolkit/Windows/pull/152.

Did a binary search on the git history to find where this started. The issue would have been showing earlier if not for the bug we fixed in [this PR](https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/109/files#diff-e690938467c6661c771e592e945bac7fdadff2aadc14f7a9d607c7b8f43ef95aR108).

The tfms just weren't getting enabled in CI because of this bug. I fixed it that commit, then it uncovered this issue we're having. I continued rewinding git in a binary search and manually applied the fix over it as I went to find where the problem was introduced.

This issue stops if you rewind [before this PR](https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/61) and manually apply the bugfix linked above, meaning that PR is the cause of the issue. 

 From that PR:
> Looks like this was originally added here to resolve MSB4011 warnings
> A short time after we found out this was a bug in Roslyn, which appears to be resolved now. Let's get this cleaned up. Thanks @Sergio0694!

Well... the Roslyn ticket I linked was for .NET Core. We're still on xamarin for MacOS. We have a NET 7 branch ready to go, but we aren't ready to commit to dropping Xamarin just yet (maybe soon?).

For now, we'll just remove this ProjectReference on MacOS.

