### PR TITLE
Resolve fix for converters on linux

### DIFF
--- a/ProjectHeads/App.Head.props
+++ b/ProjectHeads/App.Head.props
@@ -31,7 +31,9 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <ProjectReference Include="$(ToolkitConvertersSourceProject)"/>
+        <!-- This is tripping up the linux build using dotnet build as we have a duplicate reference auto-generated in tooling/MultiTarget/Generated -->
+        <!-- See: https://github.com/dotnet/msbuild/issues/2688 -->
+        <!--<ProjectReference Include="$(ToolkitConvertersSourceProject)"/>-->
       </ItemGroup>
     </Otherwise>
   </Choose>


### PR DESCRIPTION
dotnet build on linux doesn't like duplicated ProjectReference, left note for future See https://github.com/dotnet/msbuild/issues/2688

Missing piece for https://github.com/CommunityToolkit/Windows/pull/152

Have tested there on a pointer to this branch, though just cleaned up messaging as I found the msbuild bug to link to.

We can merge this in quick and then clean-up 152 so the tooling pointer stays on `main`. FYI @Arlodotexe 