### PR TITLE
Another fix for the Converters ProjectReference logic

### DIFF
--- a/ProjectHeads/App.Head.props
+++ b/ProjectHeads/App.Head.props
@@ -29,13 +29,16 @@
         <PackageReference Include="CommunityToolkit.$(DependencyVariant).Converters" Version="8.0.230801-preview"/>
       </ItemGroup>
     </When>
-    <Otherwise>
+    <!-- This is tripping up the linux build using dotnet build as we have a duplicate reference 
+        auto-generated in tooling/MultiTarget/Generated when building the all-up sample app -->
+    <!-- See: https://github.com/dotnet/msbuild/issues/2688 -->
+    <!-- TODO: We need to handle a case where a component itself references the converter package... -->
+    <!-- Only add Converters reference if we're in a single experiment that's not the Converters project itself -->
+    <When Condition="'$(IsSingleExperimentHead)' == 'true' and $(MSBuildProjectName.StartsWith('Converters')) == 'false'">
       <ItemGroup>
-        <!-- This is tripping up the linux build using dotnet build as we have a duplicate reference auto-generated in tooling/MultiTarget/Generated -->
-        <!-- See: https://github.com/dotnet/msbuild/issues/2688 -->
-        <!--<ProjectReference Include="$(ToolkitConvertersSourceProject)"/>-->
+        <ProjectReference Include="$(ToolkitConvertersSourceProject)"/>
       </ItemGroup>
-    </Otherwise>
+    </When>
   </Choose>
 
   <!-- See https://github.com/CommunityToolkit/Labs-Windows/issues/142 -->


### PR DESCRIPTION
We need to add the Converters when running in Single Component mode, as it's only included in the all-up sample app locally (when source defined).

We also need to exclude if we're building the Converters project itself.

However, if a component itself relies on the converters and we try and to build on Linux we'll hit the original issue. Workaround for now there is to build all-up sample app instead...

Tested locally that the Converters and another component both could be built now.