### PR TITLE
Fix the slash inclusion and apply same duplicate project fix

### DIFF
--- a/.github/workflows/config/Directory.Build.props
+++ b/.github/workflows/config/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
-    <RepositoryDirectory>$(MSBuildThisFileDirectory)</RepositoryDirectory>
-    <ToolingDirectory>$(RepositoryDirectory)\tooling</ToolingDirectory>
+    <RepositoryDirectory>$([MSBuild]::EnsureTrailingSlash('$(MSBuildThisFileDirectory)'))</RepositoryDirectory>
+    <ToolingDirectory>$(RepositoryDirectory)tooling</ToolingDirectory>
 
     <MajorVersion>1</MajorVersion>
     <MinorVersion>0</MinorVersion>

--- a/ProjectHeads/AllComponents/Tests.Head.AllComponents.props
+++ b/ProjectHeads/AllComponents/Tests.Head.AllComponents.props
@@ -3,7 +3,7 @@
   <Import Project="$(ToolingDirectory)\CommunityToolkit.Tests.Shared\CommunityToolkit.Tests.Shared.projitems" Label="Unit Testing Helpers" />
 
   <!-- Visual Studio likes to delete the following line - but it's needed to find the tests -->
-  <Import Project="$(RepositoryDirectory)\components\**\*.Tests.projitems" Label="Shared" />
+  <Import Project="$(RepositoryDirectory)components\**\*.Tests.projitems" Label="Shared" />
 
   <!-- Include all base code to be tested -->
   <Import Project="$(ToolingDirectory)\MultiTarget\Generated\*.props" />

--- a/ProjectHeads/AllComponents/Tests.WinAppSdk/CommunityToolkit.Tests.WinAppSdk.csproj
+++ b/ProjectHeads/AllComponents/Tests.WinAppSdk/CommunityToolkit.Tests.WinAppSdk.csproj
@@ -4,7 +4,6 @@
     <IsDeployableHead>true</IsDeployableHead>
     <IsWinAppSdk>true</IsWinAppSdk>
     <HasWinUI>true</HasWinUI>
-    <HasWinUI>true</HasWinUI>
     <WinUIMajorVersion>3</WinUIMajorVersion>
   </PropertyGroup>
 

--- a/ProjectHeads/App.Head.props
+++ b/ProjectHeads/App.Head.props
@@ -44,11 +44,11 @@
   <!-- See https://github.com/CommunityToolkit/Labs-Windows/issues/142 -->
   <ItemGroup Condition="'$(IsAllExperimentHead)' == 'true'">
     <!-- These are also included in the Samples props file, but added here to workaround https://github.com/unoplatform/uno/issues/2502 -->
-    <Content Include="$(RepositoryDirectory)components\**\samples\**\*.md" Exclude="$(RepositoryDirectory)**\**\samples\obj\**\*.md;$(RepositoryDirectory)**\**\samples\bin\**\*.md;$(RepositoryDirectory)\**\SourceAssets\**\*.md">
+    <Content Include="$(RepositoryDirectory)components\**\samples\**\*.md" Exclude="$(RepositoryDirectory)**\**\samples\obj\**\*.md;$(RepositoryDirectory)**\**\samples\bin\**\*.md;$(RepositoryDirectory)**\SourceAssets\**\*.md">
       <Link>SourceAssets/%(RecursiveDir)%(FileName)%(Extension)</Link>
     </Content>
 
-    <Content Include="$(RepositoryDirectory)components\**\samples\**\*.xaml" Exclude="$(RepositoryDirectory)**\**\samples\obj\**\*.xaml;$(RepositoryDirectory)**\**\samples\bin\**\*.xaml;$(RepositoryDirectory)\**\SourceAssets\**\*.xaml">
+    <Content Include="$(RepositoryDirectory)components\**\samples\**\*.xaml" Exclude="$(RepositoryDirectory)**\**\samples\obj\**\*.xaml;$(RepositoryDirectory)**\**\samples\bin\**\*.xaml;$(RepositoryDirectory)**\SourceAssets\**\*.xaml">
       <Link>SourceAssets/%(RecursiveDir)%(FileName)%(Extension)</Link>
     </Content>
 
@@ -57,7 +57,7 @@
       <Link>SourceAssets/%(RecursiveDir)%(FileName)%(Extension).dat</Link>
     </Content>
 
-    <Content Include="$(RepositoryDirectory)components\**\samples\**\*.png" Exclude="$(RepositoryDirectory)**\**\samples\obj\**\*.png;$(RepositoryDirectory)**\**\samples\bin\**\*.png;$(RepositoryDirectory)\**\SourceAssets\**\*.png">
+    <Content Include="$(RepositoryDirectory)components\**\samples\**\*.png" Exclude="$(RepositoryDirectory)**\**\samples\obj\**\*.png;$(RepositoryDirectory)**\**\samples\bin\**\*.png;$(RepositoryDirectory)**\SourceAssets\**\*.png">
       <Link>SourceAssets/%(RecursiveDir)%(FileName)%(Extension)</Link>
     </Content>
 

--- a/ProjectHeads/SingleComponent/Tests.Uwp/ProjectTemplate.Tests.Uwp.csproj
+++ b/ProjectHeads/SingleComponent/Tests.Uwp/ProjectTemplate.Tests.Uwp.csproj
@@ -7,6 +7,8 @@
     <IsUwp>true</IsUwp>
     <HasWinUI>true</HasWinUI>
     <WinUIMajorVersion>2</WinUIMajorVersion>
+
+    <IsSingleExperimentHead>true</IsSingleExperimentHead>
   </PropertyGroup>
 
   <Import Project="$(ToolingDirectory)\MultiTarget\EnabledTargetFrameworks.props" />

--- a/ProjectHeads/SingleComponent/Tests.WinAppSdk/ProjectTemplate.Tests.WinAppSdk.csproj
+++ b/ProjectHeads/SingleComponent/Tests.WinAppSdk/ProjectTemplate.Tests.WinAppSdk.csproj
@@ -5,6 +5,8 @@
     <IsWinAppSdk>true</IsWinAppSdk>
     <HasWinUI>true</HasWinUI>
     <WinUIMajorVersion>3</WinUIMajorVersion>
+
+    <IsSingleExperimentHead>true</IsSingleExperimentHead>
   </PropertyGroup>
 
   <Import Project="$(ToolingDirectory)\MultiTarget\EnabledTargetFrameworks.props" />

--- a/ProjectHeads/Tests.Head.props
+++ b/ProjectHeads/Tests.Head.props
@@ -19,11 +19,11 @@
         <PackageReference Include="CommunityToolkit.$(DependencyVariant).Extensions" Version="8.0.230801-preview"/>
       </ItemGroup>
     </When>
-    <Otherwise>
+    <When Condition="'$(IsSingleExperimentHead)' == 'true' and $(MSBuildProjectName.StartsWith('Extensions')) == 'false'">
       <ItemGroup>
         <ProjectReference Include="$(ToolkitExtensionSourceProject)"/>
       </ItemGroup>
-    </Otherwise>
+    </When>
   </Choose>
 
   <!-- Global Usings -->


### PR DESCRIPTION
From fixes in https://github.com/CommunityToolkit/Windows/pull/165

Basically, we were hitting issues locally with the project references for UWP based projects having double slashes in the paths.

However, fixing that brought up an old issue https://github.com/CommunityToolkit/Windows/pull/20#issuecomment-1514213118 which broke the CI which we didn't understand at the time.

It appears like it is again the fact we're double-referencing the packages between projects that are required to build the toolkit, since we use the toolkit itself to do so...

This normalizes the `$RepositoryDirectory` to include the `\` but then not add it when used.

Note that the `$ToolingDirectory` property is the opposite and does *not* include the `\`.