### PR TITLE
Pass in Date and Version PostFix separately to Pack Script

### DIFF
--- a/Scripts/PackEachExperiment.ps1
+++ b/Scripts/PackEachExperiment.ps1
@@ -1,8 +1,11 @@
 Param (
-    [Parameter(HelpMessage = "Extra properties to pass to the msbuild pack command")]
-    [string]$extraBuildProperties
+    [Parameter(HelpMessage = "Date of Build/Package")]
+    [string]$date,
+
+    [Parameter(HelpMessage = "Any postfix after build number")]
+    [string]$postfix
 )
 
 foreach ($experimentProjPath in Get-ChildItem -Recurse -Path '../../components/*/src/*.csproj') {
-  & msbuild.exe -t:pack /p:Configuration=Release /p:DebugType=Portable $experimentProjPath $extraBuildProperties
+  & msbuild.exe -t:pack /p:Configuration=Release /p:DebugType=Portable /p:DateForVersion=$date /p:PreviewVersion=$postfix $experimentProjPath
 }

--- a/ToolkitComponent.SourceProject.props
+++ b/ToolkitComponent.SourceProject.props
@@ -7,7 +7,8 @@
   <Import Project="$(ToolingDirectory)\MultiTarget\Library.props" />
 
   <PropertyGroup>
-    <Version Condition="'$(Version)' == ''">$(MajorVersion).$(MinorVersion).$([System.DateTime]::UtcNow.ToString(yyMMdd))</Version>
+    <DateForVersion Condition="'$(DateForVersion)' == ''">$([System.DateTime]::UtcNow.ToString(yyMMdd))</DateForVersion>
+    <Version Condition="'$(Version)' == ''">$(MajorVersion).$(MinorVersion).$(DateForVersion)</Version>
     <Version Condition="'$(PreviewVersion)' != ''">$(Version)-$(PreviewVersion)</Version>
     <PackageId Condition="'$(PackageId)' == ''">$(PackageIdPrefix).$(PackageIdVariant).$(ToolkitComponentName)</PackageId>
   </PropertyGroup>


### PR DESCRIPTION
Couldn't get build/PowerShell to pass properties together as one string, so added as two parameters explicitly to the script.

Tested and working as part of https://github.com/CommunityToolkit/Windows/pull/178

See commit: https://github.com/CommunityToolkit/Windows/pull/178/commits/6a14bcc0e810c4aaf23505e54b82b6aaa4382169