### PR TITLE
Clean-up Solution Generation PowerShell Script

### DIFF
--- a/GenerateAllSolution.ps1
+++ b/GenerateAllSolution.ps1
@@ -33,8 +33,14 @@ Param (
 
 # Set up constant values
 $generatedSolutionFilePath = 'CommunityToolkit.AllComponents.sln'
-$platforms = '"Any CPU;x64;x86;ARM64"'
-$slngenConfig = "--folders true --collapsefolders true --ignoreMainProject"
+$platforms = 'Any CPU;x64;x86;ARM64'
+$slngenConfig = @(
+    '--folders'
+    'true'
+    '--collapsefolders'
+    'true'
+    '--ignoreMainProject'
+)
 
 # Remove previous file if it exists
 if (Test-Path -Path $generatedSolutionFilePath)
@@ -69,8 +75,11 @@ if ($IncludeHeads -ne 'uwp')
 
 if ($UseDiagnostics.IsPresent)
 {
-    $sdkoptions = " -d"
-    $diagnostics = '-bl:slngen.binlog --consolelogger:"ShowEventId;Summary;Verbosity=Detailed" '
+    $sdkoptions = "-d"
+    $diagnostics = @(
+        '-bl:slngen.binlog'
+        '--consolelogger:"ShowEventId;Summary;Verbosity=Detailed"'
+    )
 }
 else
 {
@@ -78,8 +87,21 @@ else
     $diagnostics = ""
 }
 
-$cmd = "dotnet$sdkoptions tool run slngen -o $generatedSolutionFilePath $slngenConfig $diagnostics--platform $platforms $($projects -Join ' ')"
+$cmd = 'dotnet'
+$arguments = @(
+    $sdkoptions
+    'tool'
+    'run'
+    'slngen'
+    '-o'
+    $generatedSolutionFilePath
+    $slngenConfig
+    $diagnostics
+    '--platform'
+    $platforms
+    $projects
+)
 
-Write-Output "Running Command: $cmd"
+Write-Output "Running Command: $cmd $arguments"
 
-Invoke-Expression $cmd
+&$cmd @arguments

--- a/ProjectHeads/AllComponents/Wasm/wwwroot/web.config
+++ b/ProjectHeads/AllComponents/Wasm/wwwroot/web.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <system.web>
-    <customErrors mode="Off"/>
+    <customErrors mode="On"/>
   </system.web>
 
   <system.webServer>

--- a/ProjectHeads/SingleComponent/Wasm/wwwroot/web.config
+++ b/ProjectHeads/SingleComponent/Wasm/wwwroot/web.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <system.web>
-    <customErrors mode="Off"/>
+    <customErrors mode="On"/>
   </system.web>
 
   <system.webServer>


### PR DESCRIPTION
While setting up CodeQL here: https://github.com/CommunityToolkit/Windows/pull/190

Was investigating issues which ended up being because of CodeQL itself stripping parameter quotes (have discussion going with them).

Anyway, based on conversations in the PowerShell Discord (much thanks to `jborean` from there), cleaned up our calls to the shell in our Generate Solutions script. Figured would be good to still keep them even though they weren't the root cause. Seems like they'll be easier to read and maintain anyway.

Using this branch to also fix CodeQL related issues. The web.config needed to be updated, I filed an Uno issue about the default value: https://github.com/unoplatform/uno/issues/13414

Going to leave as draft for a sec to see if any more hits on the next scan on the cleaned-up CodeQL PR.