### PR TITLE
[Gallery] Minor tweaks

### DIFF
--- a/CommunityToolkit.App.Shared/Pages/GettingStartedPage.xaml
+++ b/CommunityToolkit.App.Shared/Pages/GettingStartedPage.xaml
@@ -1,4 +1,4 @@
-<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
 <Page x:Class="CommunityToolkit.App.Shared.Pages.GettingStartedPage"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -89,6 +89,26 @@
                 <StackPanel Margin="0,16,0,0"
                             Orientation="Vertical"
                             Spacing="8">
+
+                    <Button win:AutomationProperties.Name="Documentation on Learn">
+                        <Button.Content>
+                            <StackPanel Orientation="Horizontal"
+                                        Spacing="11">
+                                <FontIcon VerticalAlignment="Center"
+                                          FontSize="15"
+                                          Foreground="{ThemeResource TextFillColorPrimaryBrush}"
+                                          Glyph="&#xE8A5;" />
+                                <TextBlock VerticalAlignment="Center"
+                                           Foreground="{ThemeResource TextFillColorPrimaryBrush}"
+                                           Text="Documentation on Learn" />
+                            </StackPanel>
+                        </Button.Content>
+                        <interactivity:Interaction.Behaviors>
+                            <interactions:EventTriggerBehavior EventName="Click">
+                                <behaviors:NavigateToUriAction NavigateUri="https://aka.ms/toolkit/docs" />
+                            </interactions:EventTriggerBehavior>
+                        </interactivity:Interaction.Behaviors>
+                    </Button>
                     <Button win:AutomationProperties.Name="Learn more on GitHub">
                         <Button.Content>
                             <StackPanel Orientation="Horizontal"
@@ -107,6 +127,7 @@
                             </interactions:EventTriggerBehavior>
                         </interactivity:Interaction.Behaviors>
                     </Button>
+
                     <Button win:AutomationProperties.Name="Join us on Discord">
                         <Button.Content>
                             <StackPanel VerticalAlignment="Center"

--- a/CommunityToolkit.App.Shared/Pages/SettingsPage.xaml
+++ b/CommunityToolkit.App.Shared/Pages/SettingsPage.xaml
@@ -74,14 +74,14 @@
                                Text="About" />
 
                     <controls:SettingsExpander Description="© 2023. All rights reserved."
-                                               Header="Windows Community Toolkit Gallery">
+                                               Header="Windows Community Toolkit Gallery"
+                                               IsExpanded="True">
                         <controls:SettingsExpander.HeaderIcon>
                             <BitmapIcon ShowAsMonochrome="False"
                                         UriSource="ms-appx:///Assets/AppTitleBar.png" />
                         </controls:SettingsExpander.HeaderIcon>
                         <TextBlock win:IsTextSelectionEnabled="True"
                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                   Style="{StaticResource CaptionTextBlockStyle}"
                                    Text="Version 8.0.0" />
                         <controls:SettingsExpander.Items>
                             <controls:SettingsCard HorizontalContentAlignment="Left"
@@ -99,6 +99,19 @@
                                             Orientation="Vertical">
                                     <HyperlinkButton Content="ColorCode"
                                                      NavigateUri="https://aka.ms/colorcode" />
+                                </StackPanel>
+                            </controls:SettingsCard>
+                            <controls:SettingsCard HorizontalContentAlignment="Left"
+                                                   ContentAlignment="Vertical"
+                                                   Header="Useful links">
+                                <StackPanel Margin="-12,0,0,0"
+                                            Orientation="Vertical">
+                                    <HyperlinkButton Content="GitHub repository"
+                                                     NavigateUri="https://aka.ms/toolkit/windows" />
+                                    <HyperlinkButton Content="Documentation"
+                                                     NavigateUri="https://aka.ms/toolkit/docs" />
+                                    <HyperlinkButton Content="UWP Community Discord"
+                                                     NavigateUri="https://aka.ms/wct/discord" />
                                 </StackPanel>
                             </controls:SettingsCard>
                         </controls:SettingsExpander.Items>

--- a/CommunityToolkit.App.Shared/Pages/Shell.xaml
+++ b/CommunityToolkit.App.Shared/Pages/Shell.xaml
@@ -37,7 +37,6 @@
         </controls:TitleBar>
         <muxc:NavigationView x:Name="NavView"
                              Grid.Row="1"
-                             Margin="0,16,0,0"
                              IsBackButtonVisible="Collapsed"
                              IsPaneToggleButtonVisible="False"
                              ItemInvoked="NavView_ItemInvoked">


### PR DESCRIPTION
Addressing: https://github.com/CommunityToolkit/Windows/issues/195

- Removed  16px gap between titlebar and content:
![image](https://github.com/CommunityToolkit/Tooling-Windows-Submodule/assets/9866362/0561ebf2-dc34-43d4-a6f7-78221cc2e7d2)


- Added links to About card:
![image](https://github.com/CommunityToolkit/Tooling-Windows-Submodule/assets/9866362/572177c3-4b72-4152-8e91-065c84ee4aec)


- Added a Documentation button at the launch page:
![image](https://github.com/CommunityToolkit/Tooling-Windows-Submodule/assets/9866362/6fe8d13e-dd59-40e3-b805-a519a4ddffd1)
