### PR TITLE
Removed png asset workaround for library projects

### DIFF
--- a/CommunityToolkit.App.Shared/Helpers/IconHelper.cs
+++ b/CommunityToolkit.App.Shared/Helpers/IconHelper.cs
@@ -8,7 +8,7 @@ namespace CommunityToolkit.App.Shared.Helpers;
 
 public static class IconHelper
 {
-    internal const string SourceAssetsPrefix = "ms-appx:///SourceAssets/";
+    internal const string SourceAssetsPrefix = "ms-appx:///";
     internal const string FallBackControlIconPath = "ms-appx:///Assets/DefaultControlIcon.png";
 
     public static IconElement? GetCategoryIcon(ToolkitSampleCategory category)

--- a/CommunityToolkit.Tooling.SampleGen/ToolkitSampleMetadataGenerator.Documentation.cs
+++ b/CommunityToolkit.Tooling.SampleGen/ToolkitSampleMetadataGenerator.Documentation.cs
@@ -156,7 +156,8 @@ public partial class ToolkitSampleMetadataGenerator
 
                 // Get the filepath we need to be able to load the markdown file in sample app.
                 var filepath = file.Path.Split(new string[] { @"\components\", "/components/", @"\tooling\", "/tooling/" }, StringSplitOptions.RemoveEmptyEntries).LastOrDefault();
-                var iconpath = (filepath.Split(new string[] { @"\samples\", "/samples/" }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault() + "\\samples\\" + icon).Replace('\\', '/');
+
+                var iconpath = icon.Replace('\\', '/');
 
                 // Look for sample id tags
                 var matches = MarkdownRegexSampleTag.Matches(content);

--- a/ProjectHeads/App.Head.props
+++ b/ProjectHeads/App.Head.props
@@ -92,10 +92,6 @@
       <Link>SourceAssets/%(RecursiveDir)%(FileName)%(Extension).dat</Link>
     </Content>
 
-    <Content Include="$(RepositoryDirectory)components\**\samples\**\*.png" Exclude="$(RepositoryDirectory)**\**\samples\obj\**\*.png;$(RepositoryDirectory)**\**\samples\bin\**\*.png;$(RepositoryDirectory)**\SourceAssets\**\*.png">
-      <Link>SourceAssets/%(RecursiveDir)%(FileName)%(Extension)</Link>
-    </Content>
-
     <!-- Include markdown files from all samples so the head can access them in the source generator -->
     <AdditionalFiles Include="$(RepositoryDirectory)components\**\samples\**\*.md" Exclude="$(RepositoryDirectory)**\**\samples\**\obj\**\*.md;$(RepositoryDirectory)**\**\samples\**\bin\**\*.md"/>
   </ItemGroup>
@@ -104,7 +100,6 @@
   <ItemGroup Condition="'$(IsSingleExperimentHead)' == 'true' or '$(IsProjectTemplateHead)' == 'true'">
     <!-- These are also included in the Samples props file, but added here to workaround https://github.com/unoplatform/uno/issues/2502 -->
     <Content Include="$(MSBuildProjectDirectory)\..\..\samples\**\*.md" Exclude="$(MSBuildProjectDirectory)\..\..\samples\obj\**\*.md;$(MSBuildProjectDirectory)\..\..\samples\bin\**\*.md;$(MSBuildProjectDirectory)\..\..\**\SourceAssets\**\*.md" Link="SourceAssets/%(RecursiveDir)%(FileName)%(Extension)"/>
-    <Content Include="$(MSBuildProjectDirectory)\..\..\samples\**\*.png" Exclude="$(MSBuildProjectDirectory)\..\..\samples\obj\**\*.png;$(MSBuildProjectDirectory)\..\..\samples\bin\**\*.png;$(MSBuildProjectDirectory)\..\..\**\SourceAssets\**\*.png" Link="SourceAssets/%(RecursiveDir)%(FileName)%(Extension)"/>
     <Content Include="$(MSBuildProjectDirectory)\..\..\samples\**\*.xaml" Exclude="$(MSBuildProjectDirectory)\..\..\samples\obj\**\*.xaml;$(MSBuildProjectDirectory)\..\..\samples\bin\**\*.xaml;$(MSBuildProjectDirectory)\..\..\**\SourceAssets\**\*.xaml" Link="SourceAssets/%(RecursiveDir)%(FileName)%(Extension)"/>
 
     <!-- Link/.dat is a workaround for https://github.com/unoplatform/uno/issues/8649 -->


### PR DESCRIPTION
This PR closes #100, fixing an issue where png files included in the component sample library weren't showing in the sample app. 

Now that https://github.com/unoplatform/uno/issues/2502 is closed, we no longer need the library asset workaround for these files, and can include them in the csproj as library assets instead.