### PR TITLE
Add Extra Metadata about csproj file to Doc Source Generator & use for Package Links in Sample App

### DIFF
--- a/CommunityToolkit.App.Shared/Renderers/ToolkitDocumentationRenderer.xaml
+++ b/CommunityToolkit.App.Shared/Renderers/ToolkitDocumentationRenderer.xaml
@@ -230,7 +230,7 @@
                     </StackPanel>
                     <interactivity:Interaction.Behaviors>
                         <interactions:EventTriggerBehavior EventName="Click">
-                            <behaviors:NavigateToUriAction NavigateUri="{x:Bind renderer:ToolkitDocumentationRenderer.ToGitHubUri('issues', Metadata.IssueId), Mode=OneWay}" />
+                            <behaviors:NavigateToUriAction NavigateUri="{x:Bind renderer:ToolkitDocumentationRenderer.ToComponentUri(Metadata.ComponentName), Mode=OneWay}" />
                         </interactions:EventTriggerBehavior>
                     </interactivity:Interaction.Behaviors>
                 </Button>
@@ -251,21 +251,23 @@
                                            Text="Namespace" />
                                 <TextBlock FontFamily="Consolas"
                                            IsTextSelectionEnabled="True"
-                                           Text="CommunityToolkit.WinUI.Behaviors" />
+                                           Text="{x:Bind renderer:ToolkitDocumentationRenderer.ToPackageNamespace(Metadata.CsProjName), Mode=OneWay}" />
                                 <TextBlock Margin="0,24,0,0"
                                            Foreground="{StaticResource TextFillColorSecondaryBrush}"
                                            Style="{StaticResource CaptionTextBlockStyle}"
                                            Text="NuGet package" />
                                 <TextBlock IsTextSelectionEnabled="True">
                                     <Hyperlink FontFamily="Consolas"
+                                               NavigateUri="{x:Bind renderer:ToolkitDocumentationRenderer.ToPackageUri('Uwp', Metadata.CsProjName), Mode=OneWay}"
                                                TextDecorations="None">
-                                        CommunityToolkit.Uwp.Behaviors
+                                        <Run Text="{x:Bind renderer:ToolkitDocumentationRenderer.ToPackageName('Uwp', Metadata.CsProjName), Mode=OneWay}" />
                                     </Hyperlink>
                                 </TextBlock>
                                 <TextBlock IsTextSelectionEnabled="True">
                                     <Hyperlink FontFamily="Consolas"
+                                               NavigateUri="{x:Bind renderer:ToolkitDocumentationRenderer.ToPackageUri('WinUI', Metadata.CsProjName), Mode=OneWay}"
                                                TextDecorations="None">
-                                        CommunityToolkit.WinUI.Behaviors
+                                        <Run Text="{x:Bind renderer:ToolkitDocumentationRenderer.ToPackageName('WinUI', Metadata.CsProjName), Mode=OneWay}" />
                                     </Hyperlink>
                                 </TextBlock>
                             </StackPanel>

--- a/CommunityToolkit.App.Shared/Renderers/ToolkitDocumentationRenderer.xaml.cs
+++ b/CommunityToolkit.App.Shared/Renderers/ToolkitDocumentationRenderer.xaml.cs
@@ -6,6 +6,7 @@ using CommunityToolkit.Tooling.SampleGen;
 using CommunityToolkit.Tooling.SampleGen.Metadata;
 using Windows.Storage;
 using Windows.System;
+using static System.Net.WebRequestMethods;
 
 #if !HAS_UNO
 #if !WINAPPSDK
@@ -214,6 +215,24 @@ public sealed partial class ToolkitDocumentationRenderer : Page
 #endif
 
     public static Uri? ToGitHubUri(string path, int id) => IsProjectPathValid() ? new Uri($"{ProjectUrl}/{path}/{id}") : null;
+
+    public static Uri? ToComponentUri(string name) => IsProjectPathValid() ? new Uri($"{ProjectUrl}/tree/main/components/{name}") : null;
+
+    public static Uri? ToPackageUri(string platform, string projectFileName) => new Uri($"https://www.nuget.org/packages/{RemoveFileExtension(projectFileName).Replace("WinUI", platform)}");
+
+    public static string ToPackageName(string platform, string projectFileName) => RemoveFileExtension(projectFileName).Replace("WinUI", platform);
+
+    // TODO: Think this is most of the special cases with Controls and the Extensions/Triggers using the base namespace
+    // See: https://github.com/CommunityToolkit/Tooling-Windows-Submodule/issues/105#issuecomment-1698306420
+    // And: https://github.com/unoplatform/uno/issues/8750 - otherwise we could use csproj data and inject with SG.
+    public static string ToPackageNamespace(string projectFileName) => RemoveFileExtension(projectFileName) switch
+    {
+        string c when c.Contains("Controls") => "CommunityToolkit.WinUI.Controls",
+        string e when e.Contains("Extensions") || e.Contains("Triggers") => "CommunityToolkit.WinUI",
+        _ => RemoveFileExtension(projectFileName)
+    };
+
+    private static string RemoveFileExtension(string filename) => filename.Replace(".csproj", "");
 
     public static Visibility IsIdValid(int id) => id switch
     {

--- a/CommunityToolkit.Tooling.SampleGen.Tests/Helpers/TestHelpers.Compilation.cs
+++ b/CommunityToolkit.Tooling.SampleGen.Tests/Helpers/TestHelpers.Compilation.cs
@@ -50,7 +50,7 @@ public static partial class TestHelpers
         {
             if (!string.IsNullOrWhiteSpace(markdown))
             {
-                var text = new InMemoryAdditionalText(@"C:\pathtorepo\components\experiment\samples\experiment.Samples\documentation.md", markdown);
+                var text = new InMemoryAdditionalText(@"C:\pathtorepo\components\experiment\samples\documentation.md", markdown);
                 driver = driver.AddAdditionalTexts(ImmutableArray.Create<AdditionalText>(text));
             }
         }

--- a/CommunityToolkit.Tooling.SampleGen.Tests/Helpers/TestHelpers.Compilation.cs
+++ b/CommunityToolkit.Tooling.SampleGen.Tests/Helpers/TestHelpers.Compilation.cs
@@ -57,4 +57,18 @@ public static partial class TestHelpers
 
         return driver;
     }
+
+    internal static GeneratorDriver WithCsproj(this GeneratorDriver driver, params string[] csprojFilesToCreate)
+    {
+        foreach (var proj in csprojFilesToCreate)
+        {
+            if (!string.IsNullOrWhiteSpace(proj))
+            {
+                var text = new InMemoryAdditionalText(@"C:\pathtorepo\components\experiment\src\componentname.csproj", proj);
+                driver = driver.AddAdditionalTexts(ImmutableArray.Create<AdditionalText>(text));
+            }
+        }
+
+        return driver;
+    }
 }

--- a/CommunityToolkit.Tooling.SampleGen.Tests/Helpers/TestHelpers.cs
+++ b/CommunityToolkit.Tooling.SampleGen.Tests/Helpers/TestHelpers.cs
@@ -19,13 +19,14 @@ public static partial class TestHelpers
         return RunSourceGenerator<TGenerator>(compilation, markdown);
     }
 
-    internal static SourceGeneratorRunResult RunSourceGenerator<TGenerator>(this Compilation compilation, string markdown = "")
+    internal static SourceGeneratorRunResult RunSourceGenerator<TGenerator>(this Compilation compilation, string markdown = "", string csproj = "")
         where TGenerator : class, IIncrementalGenerator, new()
     {
         // Create a driver for the source generator
         var driver = compilation
             .CreateSourceGeneratorDriver(new TGenerator())
-            .WithMarkdown(markdown);
+            .WithMarkdown(markdown)
+            .WithCsproj(csproj);
 
         // Update the original compilation using the source generator
         _ = driver.RunGeneratorsAndUpdateCompilation(compilation, out Compilation generatorCompilation, out ImmutableArray<Diagnostic> postGeneratorCompilationDiagnostics);

--- a/CommunityToolkit.Tooling.SampleGen.Tests/ToolkitSampleMetadataTests.Documentation.cs
+++ b/CommunityToolkit.Tooling.SampleGen.Tests/ToolkitSampleMetadataTests.Documentation.cs
@@ -2,12 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using CommunityToolkit.Tooling.SampleGen.Attributes;
 using CommunityToolkit.Tooling.SampleGen.Diagnostics;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using CommunityToolkit.Tooling.SampleGen.Tests.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace CommunityToolkit.Tooling.SampleGen.Tests;
 
@@ -184,12 +181,15 @@ issue-id: 0
 icon: assets/icon.png
 ---
 # This is some test documentation...
-Without an invalid discussion id.";
+Without an invalid discussion-id.";
 
         var result = string.Empty.RunSourceGenerator<ToolkitSampleMetadataGenerator>(SAMPLE_ASM_NAME, markdown);
 
         result.AssertNoCompilationErrors();
         result.AssertDiagnosticsAre(DiagnosticDescriptors.MarkdownYAMLFrontMatterException, DiagnosticDescriptors.DocumentationHasNoSamples);
+
+        var diag = result.Diagnostics.First((d) => d.Descriptor == DiagnosticDescriptors.MarkdownYAMLFrontMatterException);
+        Assert.IsTrue(diag.GetMessage().Contains("discussion-id"));
     }
 
     [TestMethod]
@@ -209,12 +209,44 @@ issue-id: https://github.com/1234
 icon: assets/icon.png
 ---
 # This is some test documentation...
-Without an invalid discussion id.";
+Without an invalid issue-id.";
 
         var result = string.Empty.RunSourceGenerator<ToolkitSampleMetadataGenerator>(SAMPLE_ASM_NAME, markdown);
 
         result.AssertNoCompilationErrors();
         result.AssertDiagnosticsAre(DiagnosticDescriptors.MarkdownYAMLFrontMatterException, DiagnosticDescriptors.DocumentationHasNoSamples);
+
+        var diag = result.Diagnostics.First((d) => d.Descriptor == DiagnosticDescriptors.MarkdownYAMLFrontMatterException);
+        Assert.IsTrue(diag.GetMessage().Contains("issue-id"));
+    }
+
+    [TestMethod]
+    public void DocumentationInvalidIsExperimental()
+    {
+        string markdown = @"---
+title: Canvas Layout
+author: mhawker
+description: A canvas-like VirtualizingLayout for use in an ItemsRepeater
+keywords: CanvasLayout, ItemsRepeater, VirtualizingLayout, Canvas, Layout, Panel, Arrange
+dev_langs:
+    - csharp
+category: Controls
+subcategory: Layout
+discussion-id: 0
+issue-id: 0
+icon: assets/icon.png
+experimental: No
+---
+# This is some test documentation...
+Without an invalid experimental value.";
+
+        var result = string.Empty.RunSourceGenerator<ToolkitSampleMetadataGenerator>(SAMPLE_ASM_NAME, markdown);
+
+        result.AssertNoCompilationErrors();
+        result.AssertDiagnosticsAre(DiagnosticDescriptors.MarkdownYAMLFrontMatterException, DiagnosticDescriptors.DocumentationHasNoSamples);
+
+        var diag = result.Diagnostics.First((d) => d.Descriptor == DiagnosticDescriptors.MarkdownYAMLFrontMatterException);
+        Assert.IsTrue(diag.GetMessage().Contains("experimental"));
     }
 
     [TestMethod]
@@ -232,6 +264,7 @@ subcategory: Layout
 discussion-id: 0
 issue-id: 0
 icon: assets/icon.png
+experimental: true
 ---
 # This is some test documentation...
 Which is valid.
@@ -258,7 +291,7 @@ Which is valid.
         {
             public static System.Collections.Generic.IEnumerable<CommunityToolkit.Tooling.SampleGen.Metadata.ToolkitFrontMatter> Execute()
             {
-                yield return new CommunityToolkit.Tooling.SampleGen.Metadata.ToolkitFrontMatter() { Title = "Canvas Layout", Author = "mhawker", Description = "A canvas-like VirtualizingLayout for use in an ItemsRepeater", Keywords = "CanvasLayout, ItemsRepeater, VirtualizingLayout, Canvas, Layout, Panel, Arrange", Category = ToolkitSampleCategory.Controls, Subcategory = ToolkitSampleSubcategory.Layout, DiscussionId = 0, IssueId = 0, Icon = @"experiment/samples/assets/icon.png", FilePath = @"experiment\samples\documentation.md", SampleIdReferences = new string[] { "Sample" } };
+                yield return new CommunityToolkit.Tooling.SampleGen.Metadata.ToolkitFrontMatter() { Title = "Canvas Layout", Author = "mhawker", Description = "A canvas-like VirtualizingLayout for use in an ItemsRepeater", Keywords = "CanvasLayout, ItemsRepeater, VirtualizingLayout, Canvas, Layout, Panel, Arrange", Category = ToolkitSampleCategory.Controls, Subcategory = ToolkitSampleSubcategory.Layout, DiscussionId = 0, IssueId = 0, Icon = @"experiment/samples/assets/icon.png", FilePath = @"experiment\samples\documentation.md", SampleIdReferences = new string[] { "Sample" }, IsExperimental = true };
             }
         }
         """, "Unexpected code generated");

--- a/CommunityToolkit.Tooling.SampleGen.Tests/ToolkitSampleMetadataTests.Documentation.cs
+++ b/CommunityToolkit.Tooling.SampleGen.Tests/ToolkitSampleMetadataTests.Documentation.cs
@@ -263,7 +263,7 @@ category: Controls
 subcategory: Layout
 discussion-id: 0
 issue-id: 0
-icon: assets/icon.png
+icon: assets\icon.png
 experimental: true
 ---
 # This is some test documentation...
@@ -299,7 +299,7 @@ Which is valid.
         {
             public static System.Collections.Generic.IEnumerable<CommunityToolkit.Tooling.SampleGen.Metadata.ToolkitFrontMatter> Execute()
             {
-                yield return new CommunityToolkit.Tooling.SampleGen.Metadata.ToolkitFrontMatter() { ComponentName = "Primitives", Title = "Canvas Layout", Author = "mhawker", Description = "A canvas-like VirtualizingLayout for use in an ItemsRepeater", Keywords = "CanvasLayout, ItemsRepeater, VirtualizingLayout, Canvas, Layout, Panel, Arrange", Category = ToolkitSampleCategory.Controls, Subcategory = ToolkitSampleSubcategory.Layout, DiscussionId = 0, IssueId = 0, Icon = @"experiment/samples/assets/icon.png", FilePath = @"experiment\samples\documentation.md", SampleIdReferences = new string[] { "Sample" }, IsExperimental = true, CsProjName = @"componentname.csproj" };
+                yield return new CommunityToolkit.Tooling.SampleGen.Metadata.ToolkitFrontMatter() { ComponentName = "Primitives", Title = "Canvas Layout", Author = "mhawker", Description = "A canvas-like VirtualizingLayout for use in an ItemsRepeater", Keywords = "CanvasLayout, ItemsRepeater, VirtualizingLayout, Canvas, Layout, Panel, Arrange", Category = ToolkitSampleCategory.Controls, Subcategory = ToolkitSampleSubcategory.Layout, DiscussionId = 0, IssueId = 0, Icon = @"assets/icon.png", FilePath = @"experiment\samples\documentation.md", SampleIdReferences = new string[] { "Sample" }, IsExperimental = true, CsProjName = @"componentname.csproj" };
             }
         }
         """, "Unexpected code generated");

--- a/CommunityToolkit.Tooling.SampleGen.Tests/ToolkitSampleMetadataTests.Documentation.cs
+++ b/CommunityToolkit.Tooling.SampleGen.Tests/ToolkitSampleMetadataTests.Documentation.cs
@@ -270,6 +270,14 @@ experimental: true
 Which is valid.
 > [!SAMPLE Sample]";
 
+        string csproj = """
+<Project Sdk="MSBuild.Sdk.Extras/3.0.23">
+  <PropertyGroup>
+    <ToolkitComponentName>Primitives</ToolkitComponentName>
+  </PropertyGroup>
+</Project>
+""";
+
         var sampleProjectAssembly = SimpleSource.ToSyntaxTree()
             .CreateCompilation("MyApp.Samples")
             .ToMetadataReference();
@@ -279,7 +287,7 @@ Which is valid.
             .CreateCompilation("MyApp.Head")
             .AddReferences(sampleProjectAssembly);
 
-        var result = headCompilation.RunSourceGenerator<ToolkitSampleMetadataGenerator>(markdown);
+        var result = headCompilation.RunSourceGenerator<ToolkitSampleMetadataGenerator>(markdown, csproj);
 
         result.AssertNoCompilationErrors();
 
@@ -291,7 +299,7 @@ Which is valid.
         {
             public static System.Collections.Generic.IEnumerable<CommunityToolkit.Tooling.SampleGen.Metadata.ToolkitFrontMatter> Execute()
             {
-                yield return new CommunityToolkit.Tooling.SampleGen.Metadata.ToolkitFrontMatter() { Title = "Canvas Layout", Author = "mhawker", Description = "A canvas-like VirtualizingLayout for use in an ItemsRepeater", Keywords = "CanvasLayout, ItemsRepeater, VirtualizingLayout, Canvas, Layout, Panel, Arrange", Category = ToolkitSampleCategory.Controls, Subcategory = ToolkitSampleSubcategory.Layout, DiscussionId = 0, IssueId = 0, Icon = @"experiment/samples/assets/icon.png", FilePath = @"experiment\samples\documentation.md", SampleIdReferences = new string[] { "Sample" }, IsExperimental = true };
+                yield return new CommunityToolkit.Tooling.SampleGen.Metadata.ToolkitFrontMatter() { ComponentName = "Primitives", Title = "Canvas Layout", Author = "mhawker", Description = "A canvas-like VirtualizingLayout for use in an ItemsRepeater", Keywords = "CanvasLayout, ItemsRepeater, VirtualizingLayout, Canvas, Layout, Panel, Arrange", Category = ToolkitSampleCategory.Controls, Subcategory = ToolkitSampleSubcategory.Layout, DiscussionId = 0, IssueId = 0, Icon = @"experiment/samples/assets/icon.png", FilePath = @"experiment\samples\documentation.md", SampleIdReferences = new string[] { "Sample" }, IsExperimental = true, CsProjName = @"componentname.csproj" };
             }
         }
         """, "Unexpected code generated");

--- a/CommunityToolkit.Tooling.SampleGen/Metadata/ToolkitFrontMatter.cs
+++ b/CommunityToolkit.Tooling.SampleGen/Metadata/ToolkitFrontMatter.cs
@@ -25,4 +25,6 @@ public sealed class ToolkitFrontMatter : DocsFrontMatter
     public string? FilePath { get; set; }
     public string[]? SampleIdReferences { get; set; }
     public string? Icon { get; set; }
+    public string? ComponentName { get; set; }
+    public string? CsProjName { get; set; }
 }

--- a/CommunityToolkit.Tooling.SampleGen/Metadata/ToolkitFrontMatter.cs
+++ b/CommunityToolkit.Tooling.SampleGen/Metadata/ToolkitFrontMatter.cs
@@ -19,6 +19,7 @@ public sealed class ToolkitFrontMatter : DocsFrontMatter
     public ToolkitSampleSubcategory Subcategory { get; set; }
     public int DiscussionId { get; set; }
     public int IssueId { get; set; }
+    public bool? IsExperimental { get; set; }
 
     //// Extra Metadata needed for Sample App
     public string? FilePath { get; set; }

--- a/CommunityToolkit.Tooling.SampleGen/ToolkitSampleMetadataGenerator.Documentation.cs
+++ b/CommunityToolkit.Tooling.SampleGen/ToolkitSampleMetadataGenerator.Documentation.cs
@@ -19,6 +19,9 @@ public partial class ToolkitSampleMetadataGenerator
     private const string FrontMatterRegexTitleExpression = @"^title:\s*(?<title>.*)$";
     private static readonly Regex FrontMatterRegexTitle = new Regex(FrontMatterRegexTitleExpression, RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.Multiline);
 
+    private const string FrontMatterRegexAuthorExpression = @"^author:\s*(?<author>.*)$";
+    private static readonly Regex FrontMatterRegexAuthor = new Regex(FrontMatterRegexAuthorExpression, RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.Multiline);
+
     private const string FrontMatterRegexDescriptionExpression = @"^description:\s*(?<description>.*)$";
     private static readonly Regex FrontMatterRegexDescription = new Regex(FrontMatterRegexDescriptionExpression, RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.Multiline);
 
@@ -110,6 +113,7 @@ public partial class ToolkitSampleMetadataGenerator
 
                 // Grab all front matter fields using RegEx expressions.
                 var title = ParseYamlField(ref ctx, file.Path, ref frontmatter, FrontMatterRegexTitle, "title");
+                var author = ParseYamlField(ref ctx, file.Path, ref frontmatter, FrontMatterRegexAuthor, "author");
                 var description = ParseYamlField(ref ctx, file.Path, ref frontmatter, FrontMatterRegexDescription, "description");
                 var keywords = ParseYamlField(ref ctx, file.Path, ref frontmatter, FrontMatterRegexKeywords, "keywords");
 
@@ -204,6 +208,7 @@ public partial class ToolkitSampleMetadataGenerator
                 return new ToolkitFrontMatter()
                 {
                     Title = title!,
+                    Author = author!,
                     Description = description!,
                     Keywords = keywords!,
                     Category = categoryValue,

--- a/CommunityToolkit.Tooling.SampleGen/ToolkitSampleMetadataGenerator.Sample.cs
+++ b/CommunityToolkit.Tooling.SampleGen/ToolkitSampleMetadataGenerator.Sample.cs
@@ -38,7 +38,7 @@ public partial class ToolkitSampleMetadataGenerator : IIncrementalGenerator
         var assemblyName = context.CompilationProvider.Select((x, _) => x.Assembly.Name);
 
         // Only generate diagnostics (sample projects)
-        // Skip creating the registry for symbols in the executing assembly. This would place an incomplete registry in each sample project and cause compiler erorrs.
+        // Skip creating the registry for symbols in the executing assembly. This would place an incomplete registry in each sample project and cause compiler errors.
         Execute(symbolsInExecutingAssembly, skipRegistry: true);
 
         // Only generate the registry (project head)

--- a/ProjectHeads/App.Head.props
+++ b/ProjectHeads/App.Head.props
@@ -94,6 +94,7 @@
 
     <!-- Include markdown files from all samples so the head can access them in the source generator -->
     <AdditionalFiles Include="$(RepositoryDirectory)components\**\samples\**\*.md" Exclude="$(RepositoryDirectory)**\**\samples\**\obj\**\*.md;$(RepositoryDirectory)**\**\samples\**\bin\**\*.md"/>
+    <AdditionalFiles Include="$(RepositoryDirectory)components\**\src\**\*.csproj" />
   </ItemGroup>
 
   <!-- See https://github.com/CommunityToolkit/Labs-Windows/issues/142 -->
@@ -109,6 +110,7 @@
 
     <!-- Include markdown files from all samples so the head can access them in the source generator -->
     <AdditionalFiles Include="$(MSBuildProjectDirectory)\..\..\samples\*.md" Exclude="$(MSBuildProjectDirectory)\..\..\**\obj\**\*.md;$(MSBuildProjectDirectory)\..\..\**\bin\**\*.md"/>
+    <AdditionalFiles Include="$(MSBuildProjectDirectory)\..\..\src\**\*.csproj" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/ToolkitComponent.SampleProject.props
+++ b/ToolkitComponent.SampleProject.props
@@ -38,5 +38,6 @@
 
     <!-- Enable reading Markdown files from source generator -->
     <AdditionalFiles Include="**\*.md" Exclude="bin\**\*.md;obj\**\*.md" />
+    <AdditionalFiles Include="$(MSBuildProjectDirectory)\..\src\*.csproj" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes #105 

Tested in Windows repo with all the other changes here: https://github.com/CommunityToolkit/Windows/pull/204

This PR:
- Cleans up Doc Source Generator a bit using deconstructed tuple over Left.Right shenanigans
- Adds a full document registry test to look at the generated output
- Adds an `experimental` bool to YAML FrontMatter of docs we can use for Labs-Windows in the future for interleaving repos for sample apps
- Supports looking for `csproj` files in AdditionalFiles to get `ComponentName` property as well as filename for packages identity
- Updates the Sample App to have the 'Source Code' button open the Component folder on main on GitHub
- In the package flyout:
  - Roughly show a good namespace for the components in the document 
  - Link to both UWP and WinUI packages on NuGet.org