### PR TITLE
Fixed missing source file assets on some samples

### DIFF
--- a/CommunityToolkit.App.Shared/Renderers/ToolkitSampleRenderer.xaml.cs
+++ b/CommunityToolkit.App.Shared/Renderers/ToolkitSampleRenderer.xaml.cs
@@ -280,7 +280,7 @@ public sealed partial class ToolkitSampleRenderer : Page
         if (isAllExperimentHead)
         {
             var sampleName = simpleAssemblyName.Replace(".Samples", "");
-            return $"SourceAssets/{sampleName}/samples/{folderPath}{type.Name}";
+            return $"SourceAssets/{sampleName}/samples/{type.Name}";
         }
 
         throw new InvalidOperationException("Unable to determine if running in a single or all experiment solution.");


### PR DESCRIPTION
This PR fixes an issue where the `.xaml` and `.cs` source files were failing to load in-app for some samples.

Related #18