### PR TITLE
Fix Sample App Search

### DIFF
--- a/CommunityToolkit.App.Shared/Pages/Shell.xaml.cs
+++ b/CommunityToolkit.App.Shared/Pages/Shell.xaml.cs
@@ -162,8 +162,8 @@ public sealed partial class Shell : Page
             }
             else
             {
-                var query = searchBox.Text;
-                searchBox.ItemsSource = samplePages?.Where(s => s!.Title!.ToLower().Contains(query) || s!.Keywords!.ToLower().Contains(query) || s!.Category!.ToString().ToLower().Contains(query) || s!.Subcategory!.ToString().ToLower().Contains(query)).ToArray(); ;
+                var query = searchBox.Text.ToLower();
+                searchBox.ItemsSource = samplePages?.Where(s => s!.Title!.ToLower().Contains(query) || s!.Description!.ToLower().Contains(query) || s!.Keywords!.ToLower().Contains(query) || s!.Category!.ToString().ToLower().Contains(query) || s!.Subcategory!.ToString().ToLower().Contains(query)).ToArray();
                 return;
             }
         }

--- a/ProjectHeads/AllComponents/Uwp/Package.appxmanifest
+++ b/ProjectHeads/AllComponents/Uwp/Package.appxmanifest
@@ -9,7 +9,7 @@
   <Identity
     Name="CommunityToolkit.Samples"
     Publisher="CN=CommunityToolkit"
-    Version="1.0.0.0" />
+    Version="8.0.0.0" />
 
   <mp:PhoneIdentity PhoneProductId="0b7f1f39-b49e-4d5a-b495-13c60832c27f" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 

--- a/ProjectHeads/AllComponents/WinAppSdk/Package.appxmanifest
+++ b/ProjectHeads/AllComponents/WinAppSdk/Package.appxmanifest
@@ -9,7 +9,7 @@
   <Identity
   Name="CommunityToolkit.Samples.WinAppSdk"
   Publisher="CN=CommunityToolkit"
-    Version="1.0.0.0" />
+    Version="8.0.0.0" />
 
   <Properties>
     <DisplayName>Windows Community Toolkit Gallery</DisplayName>


### PR DESCRIPTION
Porting over from my Store SDK PR as that's breaking the build, will need to figure that out after shipping. For now I can merge that in locally when building the final app.

In the meantime though, seems like we should at least check-in the quick change I did orthogonal on that one to fix the Sample App Search.

Quick two-liner to just ensure the query is made lower case so we do a case-insensitive search.

And we'll search descriptions now, so it gives us a bit better 'fuzzy' search for people looking for different more general things.

Oh, and made 8.0.0 the default for sample app versions.