### PR TITLE
Fix issue with sample displays being blank

### DIFF
--- a/CommunityToolkit.App.Shared/Renderers/ToolkitSampleRenderer.xaml.cs
+++ b/CommunityToolkit.App.Shared/Renderers/ToolkitSampleRenderer.xaml.cs
@@ -159,21 +159,22 @@ public sealed partial class ToolkitSampleRenderer : Page
         if (XamlCode?.StartsWith("<!--  Licensed") == true ||
             XamlCode?.StartsWith("<!-- Licensed") == true)
         {
-            var lines = XamlCode.Split(Environment.NewLine).Skip(1);
-            XamlCode = string.Join(Environment.NewLine, lines).Trim();
+            // Note: We just use \n directly here as we don't know if the content will match the expected environment setup, we do know there'll be at least a \n though separating newlines, so we want to split on that, otherwise we'll skip the entire set of contents...
+            var lines = XamlCode.Split('\n').Skip(1);
+            XamlCode = string.Join('\n', lines).Trim();
         }
 
         if (CSharpCode?.StartsWith("// Licensed") == true)
         {
-            var lines = CSharpCode.Split(Environment.NewLine).Skip(3);
-            CSharpCode = string.Join(Environment.NewLine, lines).Trim();
+            var lines = CSharpCode.Split('\n').Skip(3);
+            CSharpCode = string.Join('\n', lines).Trim();
         }
 
         // Remove namespace line as not relevant to sample
         if (CSharpCode?.StartsWith("namespace") == true)
         {
-            var lines = CSharpCode.Split(Environment.NewLine).Skip(1);
-            CSharpCode = string.Join(Environment.NewLine, lines).Trim();
+            var lines = CSharpCode.Split('\n').Skip(1);
+            CSharpCode = string.Join('\n', lines).Trim();
         }
 
         RenderCode();


### PR DESCRIPTION
Fixes https://github.com/CommunityToolkit/Windows/issues/230

Not sure why we only found this out in Release mode, or I guess just from checking out on a fresh machine we used for the store build.

In either case, there was a problem where the `Environment.Newline` in C# didn't match the files being loaded by the Sample app (files seemed inconsistent which made it harder to diagnose as some samples did load).

What was happening is because the Newline wasn't detected, the code added to strip extraneous header info off of the samples before display was instead just removing all the content.

This change makes it so we only split on the single newline character `\n` instead.