### PR TITLE
Fixed Layouts category icon

### DIFF
--- a/CommunityToolkit.App.Shared/Helpers/IconHelper.cs
+++ b/CommunityToolkit.App.Shared/Helpers/IconHelper.cs
@@ -16,7 +16,7 @@ public static class IconHelper
         IconElement? iconElement = null;
         switch (category)
         {
-            case ToolkitSampleCategory.Layouts: iconElement = new FontIcon() { Glyph = "\uF58C" }; break;
+            case ToolkitSampleCategory.Layouts: iconElement = new FontIcon() { Glyph = "\uF58C", FontFamily = "Segoe Fluent Icons" }; break;
             case ToolkitSampleCategory.Controls: iconElement = new FontIcon() { Glyph = "\ue73a" }; break;
             case ToolkitSampleCategory.Animations: iconElement = new FontIcon() { Glyph = "\ue945" }; break;
             case ToolkitSampleCategory.Extensions: iconElement = new FontIcon() { Glyph = "\ue95f" }; break;


### PR DESCRIPTION
Hotfix for an issue found [here](https://github.com/CommunityToolkit/ToolkitLabs.dev/pull/1#issuecomment-1793135683). Layouts icon was broken on WebAssembly, the specific icon likely isn't available in Segoe MDL2 Assets.