### PR TITLE
Update WinAppSdk to latest 1.4.4 (1.4.231219000)

### DIFF
--- a/MultiTarget/PackageReferences/WinAppSdk.props
+++ b/MultiTarget/PackageReferences/WinAppSdk.props
@@ -1,6 +1,6 @@
 <Project>
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.4.231115000" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.4.231219000" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.2428" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR bumps our WinAppSDK dependency to the latest release version. It contains important fixes needed to add the `net8.0-windows*` TargetFramework to our packages. 

See release notes: https://learn.microsoft.com/en-us/windows/apps/windows-app-sdk/stable-channel#version-144-14231219000