### PR TITLE
Fixed component name typo in 'ToolkitExtensionSourceProject'

### DIFF
--- a/ProjectHeads/Tests.Head.props
+++ b/ProjectHeads/Tests.Head.props
@@ -14,14 +14,14 @@
   </ItemGroup>
 
   <Choose>
-    <When Condition="'$(ToolkitExtensionSourceProject)' == ''">
+    <When Condition="'$(ToolkitExtensionsSourceProject)' == ''">
       <ItemGroup>
         <PackageReference Include="CommunityToolkit.$(DependencyVariant).Extensions" Version="8.0.230907"/>
       </ItemGroup>
     </When>
     <When Condition="'$(IsSingleExperimentHead)' == 'true' and $(MSBuildProjectName.StartsWith('Extensions')) == 'false'">
       <ItemGroup>
-        <ProjectReference Include="$(ToolkitExtensionSourceProject)"/>
+        <ProjectReference Include="$(ToolkitExtensionsSourceProject)"/>
       </ItemGroup>
     </When>
   </Choose>


### PR DESCRIPTION
This PR fixes a typo in references to 'ToolkitExtensionSourceProject', submitted in tandem with https://github.com/CommunityToolkit/Windows/pull/318