### PR TITLE
Fix CI failure after update to PowerShell 7.4.0

### DIFF
--- a/GenerateAllSolution.ps1
+++ b/GenerateAllSolution.ps1
@@ -87,6 +87,9 @@ else
     $diagnostics = ""
 }
 
+# See https://learn.microsoft.com/en-us/powershell/scripting/learn/experimental-features?view=powershell-7.4#psnativecommandargumentpassing
+$PSNativeCommandArgumentPassing = 'Legacy'
+
 $cmd = 'dotnet'
 $arguments = @(
     $sdkoptions

--- a/GenerateAllSolution.ps1
+++ b/GenerateAllSolution.ps1
@@ -78,7 +78,7 @@ if ($UseDiagnostics.IsPresent)
     $sdkoptions = "-d"
     $diagnostics = @(
         '-bl:slngen.binlog'
-        '--consolelogger:"ShowEventId;Summary;Verbosity=Detailed"'
+        '--consolelogger:ShowEventId;Summary;Verbosity=Detailed'
     )
 }
 else
@@ -101,7 +101,5 @@ $arguments = @(
     $platforms
     $projects
 )
-
-Write-Output "Running Command: $cmd $arguments"
 
 &$cmd @arguments


### PR DESCRIPTION
Closes #166 

This fixes the CI failures that started to occur after the latest GitHub Actions image update, which updated PowerShell to 7.4.0 LTS by default for ubuntu-22.04.