### PR TITLE
Hotfix: pack script now runs from any directory

### DIFF
--- a/Scripts/PackEachExperiment.ps1
+++ b/Scripts/PackEachExperiment.ps1
@@ -6,6 +6,6 @@ Param (
     [string]$postfix
 )
 
-foreach ($experimentProjPath in Get-ChildItem -Recurse -Path '../../components/*/src/*.csproj') {
+foreach ($experimentProjPath in Get-ChildItem -Recurse -Path "$PSScriptRoot/../../components/*/src/*.csproj") {
   & msbuild.exe -t:pack /p:Configuration=Release /p:DebugType=Portable /p:DateForVersion=$date /p:PreviewVersion=$postfix $experimentProjPath
 }


### PR DESCRIPTION
Fixed an issue preventing PackEachExperiment.ps1 script from running from any directory