### PR TITLE
Fixed PackageId being overridden by MSBuild.Sdk.Extras import

### DIFF
--- a/MultiTarget/Library.props
+++ b/MultiTarget/Library.props
@@ -28,6 +28,4 @@
 
   <!-- Import Uno and native dependencies for all multitargeted library projects. -->
   <Import Project="$(MSBuildProjectDirectory)\Dependencies.props" Condition="Exists('$(MSBuildProjectDirectory)\Dependencies.props')" />
-  
-  <Sdk Condition="'$(IsUwp)' == 'true'" Name="MSBuild.Sdk.Extras" Version="3.0.23" />
 </Project>

--- a/ToolkitComponent.SampleProject.props
+++ b/ToolkitComponent.SampleProject.props
@@ -6,6 +6,8 @@
   <!-- Set up the MultiTarget system -->
   <Import Project="$(ToolingDirectory)\MultiTarget\Library.props" />
 
+  <Sdk Condition="'$(IsUwp)' == 'true'" Name="MSBuild.Sdk.Extras" Version="3.0.23" />
+
   <!-- Import this component's source project -->
   <ItemGroup>
     <ProjectReference Include="$(MSBuildProjectDirectory)\..\src\*.csproj" />

--- a/ToolkitComponent.SourceProject.props
+++ b/ToolkitComponent.SourceProject.props
@@ -3,18 +3,23 @@
     <Error Condition="$(ToolkitComponentName) == ''" Message="ToolkitComponentName is not defined. Please check your csproj." />
   </Target>
 
-  <!-- Set up the MultiTarget system -->
-  <Import Project="$(ToolingDirectory)\MultiTarget\Library.props" />
-
   <PropertyGroup>
     <DateForVersion Condition="'$(DateForVersion)' == ''">$([System.DateTime]::UtcNow.ToString(yyMMdd))</DateForVersion>
     <Version Condition="'$(Version)' == ''">$(MajorVersion).$(MinorVersion).$(DateForVersion)</Version>
     <Version Condition="'$(PreviewVersion)' != ''">$(Version)-$(PreviewVersion)</Version>
+  </PropertyGroup>
+
+  <!-- Set up the MultiTarget system -->
+  <Import Project="$(ToolingDirectory)\MultiTarget\Library.props" />
+
+  <PropertyGroup>
     <PackageId Condition="'$(PackageId)' == ''">$(PackageIdPrefix).$(PackageIdVariant).$(ToolkitComponentName)</PackageId>
   </PropertyGroup>
 
+  <Sdk Condition="'$(IsUwp)' == 'true'" Name="MSBuild.Sdk.Extras" Version="3.0.23" />
+
   <!-- Auto Generate our own Assembly Info -->
-    <PropertyGroup>
+  <PropertyGroup>
     <!-- Turn-off .NET based AssemblyInfo.cs generator, see below -->
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/ToolkitComponent.SourceProject.props
+++ b/ToolkitComponent.SourceProject.props
@@ -3,16 +3,13 @@
     <Error Condition="$(ToolkitComponentName) == ''" Message="ToolkitComponentName is not defined. Please check your csproj." />
   </Target>
 
-  <PropertyGroup>
-    <DateForVersion Condition="'$(DateForVersion)' == ''">$([System.DateTime]::UtcNow.ToString(yyMMdd))</DateForVersion>
-    <Version Condition="'$(Version)' == ''">$(MajorVersion).$(MinorVersion).$(DateForVersion)</Version>
-    <Version Condition="'$(PreviewVersion)' != ''">$(Version)-$(PreviewVersion)</Version>
-  </PropertyGroup>
-
   <!-- Set up the MultiTarget system -->
   <Import Project="$(ToolingDirectory)\MultiTarget\Library.props" />
 
   <PropertyGroup>
+    <DateForVersion Condition="'$(DateForVersion)' == ''">$([System.DateTime]::UtcNow.ToString(yyMMdd))</DateForVersion>
+    <Version Condition="'$(Version)' == ''">$(MajorVersion).$(MinorVersion).$(DateForVersion)</Version>
+    <Version Condition="'$(PreviewVersion)' != ''">$(Version)-$(PreviewVersion)</Version>
     <PackageId Condition="'$(PackageId)' == ''">$(PackageIdPrefix).$(PackageIdVariant).$(ToolkitComponentName)</PackageId>
   </PropertyGroup>
 


### PR DESCRIPTION
This PR fixes a regression introduced in c7ae0a0cd562080c09a507df12103ec3b84aff9c that caused the wrong PackageId to be produced for some packages.

Importing MSBuild.Sdk.Extras in the place we did caused PackageId to be defined with a default. Our tooling doesn't reassign PackageId when there's an existing value, so the value defined by MsBuild/Extras was being used instead.

 Before
![image](https://github.com/CommunityToolkit/Tooling-Windows-Submodule/assets/9384894/2b9cdbbd-0010-43a7-baa8-ec93b2301a12)

After
![image](https://github.com/CommunityToolkit/Tooling-Windows-Submodule/assets/9384894/cbb0f35f-a314-4222-9091-f8f501270e89)


