### PR TITLE
Update Microsoft.WindowsAppSdk to latest stable 1.5

### DIFF
--- a/MultiTarget/PackageReferences/WinAppSdk.props
+++ b/MultiTarget/PackageReferences/WinAppSdk.props
@@ -1,6 +1,6 @@
 <Project>
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240205001-preview1" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.2428" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.5.240227000" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.3233" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR updates our dependencies on Microsoft.WindowsAppSdk and Microsoft.Windows.Sdk.BuildTools to their latest stable releases.

Notably, this updates Microsoft.WindowsAppSdk to the stable 1.5 release.