### PR TITLE
Minor fixes to Build-Toolkit-Docs.ps1

### DIFF
--- a/Build-Toolkit-Docs.ps1
+++ b/Build-Toolkit-Docs.ps1
@@ -93,9 +93,15 @@ $componentsRoot = Resolve-Path $PSScriptRoot/../components/
 
 # For each component
 foreach ($componentFolder in Get-ChildItem -Path $componentsRoot -Directory) {
+  # Add component to TOC
   $componentName = $componentFolder.Name
 
-  # Add component to TOC
+  # Check if /samples folder exists
+  if (-not (Test-Path "$componentFolder/samples")) {
+    continue
+  }
+
+  # Get markdown docs from samples folder
   $markdownFiles = Get-ChildItem -Recurse -Path "$componentFolder/samples/**/*.md" | Where-Object { $_.FullName -notlike "*\bin\*" -and $_FullName -notlike "*\obj\*" }
   
   # If there's only one markdown file, append it to the root of the TOC

--- a/Build-Toolkit-Docs.ps1
+++ b/Build-Toolkit-Docs.ps1
@@ -109,7 +109,7 @@ foreach ($componentFolder in Get-ChildItem -Path $componentsRoot -Directory) {
     $header = GetTitleFrontMatterFromMarkdownFile $markdownFiles[0]
     $mdOutputFile = ProcessMarkdownFile $markdownFiles[0]
     
-    $tocHref = $mdOutputFile.Trim('/').Replace($OutputDir, '').Trim('\')
+    $tocHref = $mdOutputFile.Trim('/').Replace($OutputDir, '').Trim('\').Replace('\', '/')
     $tocContents += AppendTocItem $header 1 @{ "href" = $tocHref }
   }
   else {
@@ -120,7 +120,7 @@ foreach ($componentFolder in Get-ChildItem -Path $componentsRoot -Directory) {
       $header = GetTitleFrontMatterFromMarkdownFile $markdownFile
       $mdOutputFile = ProcessMarkdownFile $markdownFile
     
-      $tocHref = $mdOutputFile.Trim('/').Replace($OutputDir, '').Trim('\')
+      $tocHref = $mdOutputFile.Trim('/').Replace($OutputDir, '').Trim('\').Replace('\', '/')
       $tocContents += AppendTocItem $header 2 @{ "href" = $tocHref }
     }
   }


### PR DESCRIPTION
This PR contains two fixes applied to `./Build-Toolkit-Docs.ps1` made while putting together [this PR](https://github.com/MicrosoftDocs/CommunityToolkit/pull/393).

See commits for list of full changes.