### PR TITLE
Improved error message when consuming from Uno projects with mismatched TFMs

### DIFF
--- a/MultiTarget/WinUI.Extra.props
+++ b/MultiTarget/WinUI.Extra.props
@@ -13,6 +13,13 @@
     <TargetPlatformVersion>10.0.19041.0</TargetPlatformVersion>
   </PropertyGroup>
 
+  <!-- Workaround, improved error message when consuming from Uno projects with mismatched TFMs -->
+  <!-- See https://github.com/CommunityToolkit/Windows/issues/388 -->
+  <ItemGroup>
+    <None PackagePath="lib/net8.0-windows10.0.18362" Include="$(MSBuildThisFileDirectory)/_._" Pack="true" />
+    <None PackagePath="lib/net7.0-windows10.0.18362" Include="$(MSBuildThisFileDirectory)/_._" Pack="true" />
+  </ItemGroup>
+
   <PropertyGroup Condition="'$(IsWinAppSdk)' == 'true'">
     <!-- See https://github.com/microsoft/WindowsAppSDK/issues/3842 -->
     <UseRidGraph>true</UseRidGraph>


### PR DESCRIPTION
Closes #185

This PR introduces a small packaging workaround that improves the error message when consuming the Toolkit from a project that needs to update the Windows version in their WinAppSDK TFM. 

_Originally posted in https://github.com/CommunityToolkit/Tooling-Windows-Submodule/issues/185#issuecomment-2049782615_

> One of the possible changes to avoid error messages of this kind is to add `lib/net7.0-windows10.0.18362` and `lib/net8.0-windows10.0.18362` folder with a `_._` file in most uno-referencing packages. This would prevent transitive dependencies to go to the wrong TargetFramework. It won't allow for the build to work, but it would not be that much misleading.