### PR TITLE
Use PackageId as AssemblyName

### DIFF
--- a/ToolkitComponent.SourceProject.props
+++ b/ToolkitComponent.SourceProject.props
@@ -11,6 +11,7 @@
     <Version Condition="'$(Version)' == ''">$(MajorVersion).$(MinorVersion).$(DateForVersion)</Version>
     <Version Condition="'$(PreviewVersion)' != ''">$(Version)-$(PreviewVersion)</Version>
     <PackageId Condition="'$(PackageId)' == ''">$(PackageIdPrefix).$(PackageIdVariant).$(ToolkitComponentName)</PackageId>
+    <AssemblyName>$(PackageId)</AssemblyName>
   </PropertyGroup>
 
   <Sdk Condition="'$(IsUwp)' == 'true'" Name="MSBuild.Sdk.Extras" Version="3.0.23" />


### PR DESCRIPTION
This PR updates our tooling to use the PackageId as the AssemblyName for components.

It required changes in both Tooling and any components with a custom PackageId due to the single-import. Hopefully this will get cleaner when we have nested components (https://github.com/CommunityToolkit/Tooling-Windows-Submodule/issues/187).

Note that any components using a custom PackageId will need to be updated to define their `PackageId` _before_ importing `ToolkitComponent.SourceProject.props`, which requires importing the `PackageIdVariant` prop from `MultiTarget\WinUI.TargetVersion.props` first.