### PR TITLE
Enable AoT for net8 in Release

### DIFF
--- a/MultiTarget/AvailableTargetFrameworks.props
+++ b/MultiTarget/AvailableTargetFrameworks.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
         <UwpTargetFramework>uap10.0.17763</UwpTargetFramework>
-        <WinAppSdkTargetFramework>net6.0-windows10.0.22621.0;net7.0-windows10.0.22621.0;net8.0-windows10.0.22621.0;</WinAppSdkTargetFramework>
+        <WinAppSdkTargetFramework>net8.0-windows10.0.22621.0;net7.0-windows10.0.22621.0;net6.0-windows10.0.22621.0;</WinAppSdkTargetFramework>
         
         <WasmHeadTargetFramework>net7.0</WasmHeadTargetFramework>
         <LinuxHeadTargetFramework>net7.0</LinuxHeadTargetFramework>

--- a/MultiTarget/DefinedConstants.props
+++ b/MultiTarget/DefinedConstants.props
@@ -15,6 +15,10 @@
         <DefineConstants Condition="'$(IsWpf)' == 'true'">$(DefineConstants);HAS_UNO_SKIA;__SKIA__;WINDOWS_WPF;</DefineConstants>
         <DefineConstants Condition="'$(IsGtk)' == 'true'">$(DefineConstants);HAS_UNO_SKIA;__SKIA__;__GTK__;</DefineConstants>
 
+        <DefineConstants Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">$(DefineConstants);NET8_0_OR_GREATER</DefineConstants>
+        <DefineConstants Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">$(DefineConstants);NET7_0_OR_GREATER</DefineConstants>
+        <DefineConstants Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">$(DefineConstants);NET6_0_OR_GREATER</DefineConstants>
+
         <DefineConstants Condition="$(IsAllExperimentHead) == 'true'">$(DefineConstants);ALL_SAMPLES</DefineConstants>
     </PropertyGroup>
 </Project>

--- a/MultiTarget/EnabledTargetFrameworks.props
+++ b/MultiTarget/EnabledTargetFrameworks.props
@@ -1,5 +1,6 @@
 <Project>
     <PropertyGroup>
+        <UwpTargetFramework>uap10.0.17763</UwpTargetFramework>
         <WinAppSdkTargetFramework>net8.0-windows10.0.22621.0;net7.0-windows10.0.22621.0;net6.0-windows10.0.22621.0;</WinAppSdkTargetFramework>
         
         <WasmHeadTargetFramework>net7.0</WasmHeadTargetFramework>

--- a/MultiTarget/EnabledTargetFrameworks.props
+++ b/MultiTarget/EnabledTargetFrameworks.props
@@ -1,7 +1,6 @@
 <Project>
     <PropertyGroup>
-        <UwpTargetFramework>uap10.0.17763</UwpTargetFramework>
-        <WinAppSdkTargetFramework>net6.0-windows10.0.22621.0;net7.0-windows10.0.22621.0;net8.0-windows10.0.22621.0;</WinAppSdkTargetFramework>
+        <WinAppSdkTargetFramework>net8.0-windows10.0.22621.0;net7.0-windows10.0.22621.0;net6.0-windows10.0.22621.0;</WinAppSdkTargetFramework>
         
         <WasmHeadTargetFramework>net7.0</WasmHeadTargetFramework>
         <LinuxHeadTargetFramework>net7.0</LinuxHeadTargetFramework>
@@ -17,4 +16,3 @@
         <DotnetCommonTargetFramework>net7.0</DotnetCommonTargetFramework>
     </PropertyGroup>
 </Project>
- 

--- a/ProjectHeads/Head.WinAppSdk.props
+++ b/ProjectHeads/Head.WinAppSdk.props
@@ -15,7 +15,8 @@
   <Import Project="$(MSBuildThisFileDirectory)\..\MultiTarget\WinUI.Extra.props" />
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
-      <PublishAot>true</PublishAot>
+      <!-- Set to true when WinAppSdk releases AoT support in 1.6+ -->
+      <PublishAot>false</PublishAot>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ProjectHeads/Head.WinAppSdk.props
+++ b/ProjectHeads/Head.WinAppSdk.props
@@ -14,6 +14,10 @@
   <Import Project="$(MSBuildThisFileDirectory)\..\MultiTarget\PackageReferences\WinAppSdk.props" />
   <Import Project="$(MSBuildThisFileDirectory)\..\MultiTarget\WinUI.Extra.props" />
 
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+      <PublishAot>true</PublishAot>
+  </PropertyGroup>
+
   <ItemGroup>
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>

--- a/ToolkitComponent.SourceProject.props
+++ b/ToolkitComponent.SourceProject.props
@@ -15,6 +15,10 @@
 
   <Sdk Condition="'$(IsUwp)' == 'true'" Name="MSBuild.Sdk.Extras" Version="3.0.23" />
 
+  <PropertyGroup>
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
+  </PropertyGroup>
+
   <!-- Auto Generate our own Assembly Info -->
   <PropertyGroup>
     <!-- Turn-off .NET based AssemblyInfo.cs generator, see below -->


### PR DESCRIPTION
This PR contains the tooling changes needed to enable [AoT](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/?tabs=net8plus%2Cwindows) functionality on net8/WinAppSdk:
- Enables Aot when running under .NET 8 in release mode
- Defines missing `NET8_0_OR_GREATER` compilation conditionals
- Switches to net8 as the primary TFM for the WinAppSDK head