### PR TITLE
Update Uno version, Uno TFMs to .NET 8

### DIFF
--- a/CommunityToolkit.App.Shared/App.xaml.cs
+++ b/CommunityToolkit.App.Shared/App.xaml.cs
@@ -12,10 +12,10 @@ namespace CommunityToolkit.App.Shared;
 public sealed partial class App : Application
 {
     // MacOS and iOS don't know the correct type without a full namespace declaration, confusing it with NSWindow and UIWindow.
-    // Using static will not work.
-#if WINAPPSDK
-    public static Microsoft.UI.Xaml.Window currentWindow = Microsoft.UI.Xaml.Window.Current;
-#else
+    // 'using static' will not work.
+#if WINUI3
+    public static Microsoft.UI.Xaml.Window? currentWindow = Microsoft.UI.Xaml.Window.Current;
+#elif WINUI2
     private static Windows.UI.Xaml.Window? currentWindow = Windows.UI.Xaml.Window.Current;
 #endif
 

--- a/CommunityToolkit.App.Shared/App.xaml.cs
+++ b/CommunityToolkit.App.Shared/App.xaml.cs
@@ -16,7 +16,7 @@ public sealed partial class App : Application
 #if WINAPPSDK
     public static Microsoft.UI.Xaml.Window currentWindow = Microsoft.UI.Xaml.Window.Current;
 #else
-    private static Windows.UI.Xaml.Window currentWindow = Windows.UI.Xaml.Window.Current;
+    private static Windows.UI.Xaml.Window? currentWindow = Windows.UI.Xaml.Window.Current;
 #endif
 
     /// <summary>
@@ -41,28 +41,34 @@ public sealed partial class App : Application
         currentWindow.AppWindow.SetIcon("Assets/Icon.ico");
         currentWindow.SystemBackdrop = new MicaBackdrop();
 #if ALL_SAMPLES
-        currentWindow.AppWindow.TitleBar.ExtendsContentIntoTitleBar = true;
-        currentWindow.AppWindow.TitleBar.ButtonBackgroundColor = Microsoft.UI.Colors.Transparent;
+        if (currentWindow is not null)
+        {
+            currentWindow.AppWindow.TitleBar.ExtendsContentIntoTitleBar = true;
+            currentWindow.AppWindow.TitleBar.ButtonBackgroundColor = Microsoft.UI.Colors.Transparent;
+        }
 #endif
 #endif
 
         // Do not repeat app initialization when the Window already has content,
         // just ensure that the window is active
-        if (currentWindow.Content is not Frame rootFrame)
+        if (currentWindow is not null && currentWindow.Content is not Frame)
         {
             // Create a Frame to act as the navigation context and navigate to the first page
-            currentWindow.Content = rootFrame = new Frame();
-
-            rootFrame.NavigationFailed += OnNavigationFailed;
+            currentWindow.Content = new Frame();
         }
 
+        if (currentWindow?.Content is Frame rootFrame)
+        {
+            rootFrame.NavigationFailed += OnNavigationFailed;
+
 #if !WINAPPSDK
-        if (e.PrelaunchActivated == false)
+            if (e.PrelaunchActivated == false)
 #endif
-            rootFrame.Navigate(typeof(AppLoadingView), e.Arguments);
+                rootFrame.Navigate(typeof(AppLoadingView), e.Arguments);
+        }
 
         // Ensure the current window is active
-        currentWindow.Activate();
+        currentWindow?.Activate();
     }
 
     /// <summary>

--- a/CommunityToolkit.App.Shared/Pages/Shell.xaml.cs
+++ b/CommunityToolkit.App.Shared/Pages/Shell.xaml.cs
@@ -20,7 +20,7 @@ public sealed partial class Shell : Page
     public Shell()
     {
         this.InitializeComponent();
-#if WINAPPSDK
+#if WINDOWS_WINAPPSDK
         appTitleBar.Window = App.currentWindow;
 #else
         BackdropMaterial.SetApplyToRootOrPageBackground(this, true);

--- a/CommunityToolkit.App.Shared/Pages/Shell.xaml.cs
+++ b/CommunityToolkit.App.Shared/Pages/Shell.xaml.cs
@@ -21,7 +21,8 @@ public sealed partial class Shell : Page
     {
         this.InitializeComponent();
 #if WINDOWS_WINAPPSDK
-        appTitleBar.Window = App.currentWindow;
+        if (App.currentWindow is not null)
+            appTitleBar.Window = App.currentWindow;
 #else
         BackdropMaterial.SetApplyToRootOrPageBackground(this, true);
 #endif

--- a/CommunityToolkit.App.Shared/Pages/TabbedPage.xaml.cs
+++ b/CommunityToolkit.App.Shared/Pages/TabbedPage.xaml.cs
@@ -34,7 +34,7 @@ public sealed partial class TabbedPage : Page
     public TabbedPage()
     {
         this.InitializeComponent();
-#if WINAPPSDK
+#if WINDOWS_WINAPPSDK
         appTitleBar.Window = App.currentWindow;
 #else
         BackdropMaterial.SetApplyToRootOrPageBackground(this, true);

--- a/CommunityToolkit.App.Shared/Pages/TabbedPage.xaml.cs
+++ b/CommunityToolkit.App.Shared/Pages/TabbedPage.xaml.cs
@@ -35,7 +35,8 @@ public sealed partial class TabbedPage : Page
     {
         this.InitializeComponent();
 #if WINDOWS_WINAPPSDK
-        appTitleBar.Window = App.currentWindow;
+        if (App.currentWindow is not null)
+            appTitleBar.Window = App.currentWindow;
 #else
         BackdropMaterial.SetApplyToRootOrPageBackground(this, true);
 #endif

--- a/MultiTarget/AvailableTargetFrameworks.props
+++ b/MultiTarget/AvailableTargetFrameworks.props
@@ -7,7 +7,7 @@
         <LinuxHeadTargetFramework>net8.0</LinuxHeadTargetFramework>
         <WpfHeadTargetFramework>net8.0</WpfHeadTargetFramework>
         
-        <AndroidLibTargetFramework>net8.0-android33.0</AndroidLibTargetFramework>
+        <AndroidLibTargetFramework>net8.0-android30.0</AndroidLibTargetFramework>
         <MacOSLibTargetFramework>net8.0-maccatalyst</MacOSLibTargetFramework>
         <iOSLibTargetFramework>net8.0-ios</iOSLibTargetFramework>
 

--- a/MultiTarget/AvailableTargetFrameworks.props
+++ b/MultiTarget/AvailableTargetFrameworks.props
@@ -7,7 +7,7 @@
         <LinuxHeadTargetFramework>net8.0</LinuxHeadTargetFramework>
         <WpfHeadTargetFramework>net8.0</WpfHeadTargetFramework>
         
-        <AndroidLibTargetFramework>net8.0-android30.0</AndroidLibTargetFramework>
+        <AndroidLibTargetFramework>net8.0-android34.0</AndroidLibTargetFramework>
         <MacOSLibTargetFramework>net8.0-maccatalyst</MacOSLibTargetFramework>
         <iOSLibTargetFramework>net8.0-ios</iOSLibTargetFramework>
 

--- a/MultiTarget/AvailableTargetFrameworks.props
+++ b/MultiTarget/AvailableTargetFrameworks.props
@@ -3,21 +3,21 @@
         <UwpTargetFramework>uap10.0.17763</UwpTargetFramework>
         <WinAppSdkTargetFramework>net6.0-windows10.0.22621.0;net7.0-windows10.0.22621.0;net8.0-windows10.0.22621.0;</WinAppSdkTargetFramework>
         
-        <WasmHeadTargetFramework>net7.0</WasmHeadTargetFramework>
-        <LinuxHeadTargetFramework>net7.0</LinuxHeadTargetFramework>
-        <WpfHeadTargetFramework>net7.0</WpfHeadTargetFramework>
+        <WasmHeadTargetFramework>net8.0</WasmHeadTargetFramework>
+        <LinuxHeadTargetFramework>net8.0</LinuxHeadTargetFramework>
+        <WpfHeadTargetFramework>net8.0</WpfHeadTargetFramework>
         
-        <AndroidLibTargetFramework>net7.0-android33.0</AndroidLibTargetFramework>
-        <MacOSLibTargetFramework>net7.0-maccatalyst</MacOSLibTargetFramework>
-        <iOSLibTargetFramework>net7.0-ios</iOSLibTargetFramework>
+        <AndroidLibTargetFramework>net8.0-android33.0</AndroidLibTargetFramework>
+        <MacOSLibTargetFramework>net8.0-maccatalyst</MacOSLibTargetFramework>
+        <iOSLibTargetFramework>net8.0-ios</iOSLibTargetFramework>
 
         <!-- Used for comparison to current TargetFramework -->
-        <LinuxLibTargetFramework>net7.0</LinuxLibTargetFramework>
-        <WasmLibTargetFramework>net7.0</WasmLibTargetFramework>
-        <WpfLibTargetFramework>net7.0</WpfLibTargetFramework>
+        <LinuxLibTargetFramework>net8.0</LinuxLibTargetFramework>
+        <WasmLibTargetFramework>net8.0</WasmLibTargetFramework>
+        <WpfLibTargetFramework>net8.0</WpfLibTargetFramework>
 
         <!-- Used for defining TargetFramework under platforms that need it -->
         <DotnetStandardCommonTargetFramework>netstandard2.0</DotnetStandardCommonTargetFramework>
-        <DotnetCommonTargetFramework>net7.0</DotnetCommonTargetFramework>
+        <DotnetCommonTargetFramework>net8.0</DotnetCommonTargetFramework>
     </PropertyGroup>
 </Project>

--- a/MultiTarget/EnabledTargetFrameworks.props
+++ b/MultiTarget/EnabledTargetFrameworks.props
@@ -2,19 +2,18 @@
     <PropertyGroup>
         <UwpTargetFramework>uap10.0.17763</UwpTargetFramework>
         <WinAppSdkTargetFramework>net6.0-windows10.0.22621.0;net7.0-windows10.0.22621.0;net8.0-windows10.0.22621.0;</WinAppSdkTargetFramework>
-        
-        <WasmHeadTargetFramework>net7.0</WasmHeadTargetFramework>
-        <LinuxHeadTargetFramework>net7.0</LinuxHeadTargetFramework>
-        <WpfHeadTargetFramework>net7.0</WpfHeadTargetFramework>
+
+        <WasmHeadTargetFramework>net8.0</WasmHeadTargetFramework>
+        <LinuxHeadTargetFramework>net8.0</LinuxHeadTargetFramework>
+        <WpfHeadTargetFramework>net8.0</WpfHeadTargetFramework>
 
         <!-- Used for comparison to current TargetFramework -->
-        <LinuxLibTargetFramework>net7.0</LinuxLibTargetFramework>
-        <WasmLibTargetFramework>net7.0</WasmLibTargetFramework>
-        <WpfLibTargetFramework>net7.0</WpfLibTargetFramework>
+        <LinuxLibTargetFramework>net8.0</LinuxLibTargetFramework>
+        <WasmLibTargetFramework>net8.0</WasmLibTargetFramework>
+        <WpfLibTargetFramework>net8.0</WpfLibTargetFramework>
 
         <!-- Used for defining TargetFramework under platforms that need it -->
         <DotnetStandardCommonTargetFramework>netstandard2.0</DotnetStandardCommonTargetFramework>
-        <DotnetCommonTargetFramework>net7.0</DotnetCommonTargetFramework>
+        <DotnetCommonTargetFramework>net8.0</DotnetCommonTargetFramework>
     </PropertyGroup>
 </Project>
- 

--- a/MultiTarget/PackageReferences/Uno.props
+++ b/MultiTarget/PackageReferences/Uno.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <CommonUnoPackageVersion>5.1.87</CommonUnoPackageVersion>
+        <CommonUnoPackageVersion>5.2.132</CommonUnoPackageVersion>
     </PropertyGroup>
 
     <!-- This file is modified by UseUnoWinUI.ps1 to switch between WinUI 2 and 3 under Uno Platform -->

--- a/ProjectHeads/App.Head.Wasm.props
+++ b/ProjectHeads/App.Head.Wasm.props
@@ -60,12 +60,12 @@
 
   <ItemGroup>
     <PackageReference Include="Markdig" Version="0.31.0" />
-    <PackageReference Include="Microsoft.Windows.Compatibility" Version="7.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
-    <PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.6.0-dev.2" />
-    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="4.9.45" />
-    <PackageReference Include="Uno.Wasm.Bootstrap" Version="7.0.29" />
-    <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="7.0.29" />
+    <PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.8.0-dev.1" />
+    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="5.2.132" />
+    <PackageReference Include="Uno.Wasm.Bootstrap" Version="8.0.14" />
+    <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="8.0.14" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ProjectHeads/SingleComponent/WinAppSdk/ProjectTemplate.WinAppSdk.csproj
+++ b/ProjectHeads/SingleComponent/WinAppSdk/ProjectTemplate.WinAppSdk.csproj
@@ -5,7 +5,7 @@
     <IsDeployableHead>true</IsDeployableHead>
     <IsWinAppSdk>true</IsWinAppSdk>
     <HasWinUI>true</HasWinUI>
-    <WinUIMajorVersion>2</WinUIMajorVersion>
+    <WinUIMajorVersion>3</WinUIMajorVersion>
 
     <IsSingleExperimentHead>true</IsSingleExperimentHead>
   </PropertyGroup>


### PR DESCRIPTION
This PR:
- Updates our Uno packages to the latest stable version
- Closes #182. Updates the TFMs that Uno runs on from net7.0 to net8.0
- Fixes any issues that arise from the move to net8.0

