### PR TITLE
Fix a rendering problem related to markdown table

### DIFF
--- a/CommunityToolkit.App.Shared/Renderers/ToolkitDocumentationRenderer.xaml.cs
+++ b/CommunityToolkit.App.Shared/Renderers/ToolkitDocumentationRenderer.xaml.cs
@@ -154,7 +154,7 @@ public sealed partial class ToolkitDocumentationRenderer : Page
         // TODO: https://github.com/CommunityToolkit/Labs-Windows/issues/142
         // MSBuild uses wildcard to find the files, and the wildcards decide where they end up
         // Single experiments use relative paths, the allExperiment head uses absolute paths that grab from all experiments
-        // The wildcard captures decide the paths. This discrepency is accounted for manually.
+        // The wildcard captures decide the paths. This discrepancy is accounted for manually.
         // Logic here is the exact same that MSBuild uses to find and include the files we need.
         var assemblyName = typeof(ToolkitSampleRenderer).Assembly.GetName().Name;
         if (string.IsNullOrWhiteSpace(assemblyName))
@@ -178,7 +178,7 @@ public sealed partial class ToolkitDocumentationRenderer : Page
             var textContents = await FileIO.ReadTextAsync(file);
 
             // Remove YAML - need to use array overload as single string not supported on .NET Standard 2.0
-            var blocks = textContents.Split(new[] { "---" }, StringSplitOptions.RemoveEmptyEntries);
+            var blocks = textContents.Split(new[] { "---" }, 2, StringSplitOptions.RemoveEmptyEntries);
 
             return blocks.LastOrDefault() ?? "Couldn't find content after YAML Front Matter removal.";
         }


### PR DESCRIPTION
Before:
![image](https://github.com/CommunityToolkit/Tooling-Windows-Submodule/assets/63725840/f0496744-bf01-4842-9c0b-c07fa1be5aa5)

After:
![image](https://github.com/CommunityToolkit/Tooling-Windows-Submodule/assets/63725840/4b4d689b-9255-4deb-a685-f2c752d273b0)

No other incompatibility or effects have been spotted when testing myself.

TL; DR
------
## Description
There's a problem when using the Community Toolkit: it seems that the markdown format table wasn't rendered correctly. In the YAML-Markdown:
```
---
author: 
...
---
*some content...*
*a table begins*
|   A  | ...
|-----|-----|...
```
the Code behind `.\CommunityToolkit.App.Shared\Renderers\ToolkitDocumentationRenderer.xaml.cs` wasn't correct when discarding the YAML part. It uses delimiter "---" so the table was teared apart while parsing.
to fix this, modified the parse function for discarding YAML part while not affecting markdown content below.

## Testing
All markdown files in [main repo (components/Extensions/samples)](https://github.com/CommunityToolkit/Windows/tree/main/components/Extensions/samples)  have been examined, and no other problems or breaks were found. The fix was tested using the CommunityToolkit.App.Uwp (Universal Windows) application, and it rendered the tables correctly.

*plus, fix an unnecessary typo in that function.* 