### PR TITLE
Improved navigation, keep GroupNavigationItemData collapsed until needed

### DIFF
--- a/CommunityToolkit.App.Shared/Helpers/NavigationViewHelper.cs
+++ b/CommunityToolkit.App.Shared/Helpers/NavigationViewHelper.cs
@@ -72,7 +72,7 @@ public static class NavigationViewHelper
             {
                 Content = subcategoryGroup.Key,
                 SelectsOnInvoked = false,
-                IsExpanded = true,
+                IsExpanded = false,
                 Style = (Style)App.Current.Resources["SubcategoryNavigationViewItemStyle"],
             }, subcategoryGroup.ToArray());
         }


### PR DESCRIPTION
The change in this PR makes it easier to manage grouped navigation items in the sample gallery by keeping grouped items collapsed until the page is opened. 

Usability improvement is especially noticeable when expanding multiple groups with many items.

Before:
![image](https://github.com/CommunityToolkit/Tooling-Windows-Submodule/assets/9384894/802e678b-15a6-4911-8069-cfda8c0d1006)

After:
![image](https://github.com/CommunityToolkit/Tooling-Windows-Submodule/assets/9384894/505ce9ca-9e2c-492c-a63a-a26fac65649f)