### PR TITLE
Bump MSTest and VSTest to latest versions

### DIFF
--- a/CommunityToolkit.Tooling.SampleGen.Tests/CommunityToolkit.Tooling.SampleGen.Tests.csproj
+++ b/CommunityToolkit.Tooling.SampleGen.Tests/CommunityToolkit.Tooling.SampleGen.Tests.csproj
@@ -10,9 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="MSTest" Version="3.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CommunityToolkit.Tooling.TestGen.Tests/CommunityToolkit.Tooling.TestGen.Tests.csproj
+++ b/CommunityToolkit.Tooling.TestGen.Tests/CommunityToolkit.Tooling.TestGen.Tests.csproj
@@ -9,9 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="MSTest" Version="3.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ProjectHeads/Tests.Head.WinAppSdk.props
+++ b/ProjectHeads/Tests.Head.WinAppSdk.props
@@ -6,7 +6,7 @@
   <Import Project="$(MSBuildThisFileDirectory)\Head.WinAppSdk.props"/>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="17.1.0">
+    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="17.10.0">
       <ExcludeAssets>build</ExcludeAssets>
     </PackageReference>
   </ItemGroup>

--- a/ProjectHeads/Tests.Head.props
+++ b/ProjectHeads/Tests.Head.props
@@ -7,8 +7,7 @@
 
   <!-- Test Dependencies -->
   <ItemGroup>
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10"/>
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10"/>
+    <PackageReference Include="MSTest" Version="3.5.0" />
 
     <ProjectReference Include="$(ToolingDirectory)\CommunityToolkit.Tooling.TestGen\CommunityToolkit.Tooling.TestGen.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="True" />
   </ItemGroup>


### PR DESCRIPTION
I am using `MSTest` meta-package that ensure versions of adapter and framework are aligned. It also add MSTest analyzer that could come handy.