### PR TITLE
Build-Toolkit-Components.ps1 to not require PreviewVersion parameter

### DIFF
--- a/Build-Toolkit-Components.ps1
+++ b/Build-Toolkit-Components.ps1
@@ -15,7 +15,7 @@
     Specifies the date for versioning in 'YYMMDD' format. The default value is the current date.
 
 .PARAMETER PreviewVersion
-    Specifies the preview version to use if packaging is enabled. Appended with a dash after the version number (formatted Version-PreviewVersion). This parameter is required when NupkgOutput is supplied.
+    Specifies the preview version to use if packaging is enabled. Appended with a dash after the version number (formatted Version-PreviewVersion). This parameter is optional.
 
 .PARAMETER NupkgOutput
     Specifies the output directory for .nupkg files. This parameter is optional. When supplied, the components will also be packed and nupkg files will be output to the specified directory.
@@ -112,11 +112,6 @@ if ($Components -eq @('all')) {
 
 if ($ExcludeComponents) {
     $Components = $Components | Where-Object { $_ -notin $ExcludeComponents }
-}
-
-# Check if NupkgOutput is supplied without PreviewVersion
-if ($NupkgOutput -and -not $PreviewVersion) {
-    throw "PreviewVersion is required when NupkgOutput is supplied."
 }
 
 # Use the specified MultiTarget TFM and WinUI version

--- a/Build-Toolkit-Components.ps1
+++ b/Build-Toolkit-Components.ps1
@@ -134,9 +134,7 @@ function Invoke-MSBuildWithBinlog {
         $msbuildArgs += "-t:Clean,Build,Pack"
         $msbuildArgs += "/p:PackageOutputPath=$NupkgOutput"
         $msbuildArgs += "/p:DateForVersion=$DateForVersion"
-        if ($PreviewVersion) {
-             $msbuildArgs += "/p:PreviewVersion=$PreviewVersion"
-        }
+        $msbuildArgs += "/p:PreviewVersion=$PreviewVersion"
     }
     else {
         $msbuildArgs += "-t:Clean,Build"

--- a/Build-Toolkit-Components.ps1
+++ b/Build-Toolkit-Components.ps1
@@ -134,7 +134,9 @@ function Invoke-MSBuildWithBinlog {
         $msbuildArgs += "-t:Clean,Build,Pack"
         $msbuildArgs += "/p:PackageOutputPath=$NupkgOutput"
         $msbuildArgs += "/p:DateForVersion=$DateForVersion"
-        $msbuildArgs += "/p:PreviewVersion=$PreviewVersion"
+        if ($PreviewVersion) {
+             $msbuildArgs += "/p:PreviewVersion=$PreviewVersion"
+        }
     }
     else {
         $msbuildArgs += "-t:Clean,Build"


### PR DESCRIPTION
This is blocking release where we don't have a PreviewVersion postfix to our build number.