### PR TITLE
Update Microsoft.WindowsAppSDK to 1.6-preview2

### DIFF
--- a/MultiTarget/PackageReferences/WinAppSdk.props
+++ b/MultiTarget/PackageReferences/WinAppSdk.props
@@ -1,6 +1,6 @@
 <Project>
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.240807006-preview1" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.240821007-preview2" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2730-prerelease" />
   </ItemGroup>

--- a/MultiTarget/WinUI.Extra.props
+++ b/MultiTarget/WinUI.Extra.props
@@ -33,7 +33,9 @@
     
     <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 8">win-x86;win-x64;win-arm64</RuntimeIdentifiers> 
     <RuntimeIdentifiers Condition="8 > $([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)'))">win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
-    <WindowsSdkPackageVersion>10.0.22621.37-preview</WindowsSdkPackageVersion>
+
+    <WindowsSdkPackageVersion Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 8">10.0.22621.41</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion Condition="8 > $([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)'))">10.0.22621.38</WindowsSdkPackageVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsUno)' == 'true'">

--- a/MultiTarget/WinUI.Extra.props
+++ b/MultiTarget/WinUI.Extra.props
@@ -61,23 +61,4 @@
       <HintPath Condition="Exists('c:\Program Files\Microsoft Visual Studio\2022\Preview\Common7\IDE\Extensions\Xamarin.VisualStudio')">c:\Program Files\Microsoft Visual Studio\2022\Preview\Common7\IDE\Extensions\Xamarin.VisualStudio\Xamarin.Mac.dll</HintPath>
     </Reference>
   </ItemGroup>
-
-    <!--
-    Workaround for WindowsAppSdk 1.6
-    Track https://github.com/CommunityToolkit/Labs-Windows/pull/561#issuecomment-2274727870
-    -->
-  <Target Condition="'$(IsWinAppSdk)' == 'true'" Name="CsWinRTRemoveXamlDllReferences" AfterTargets="ResolveTargetingPackAssets;ResolveReferences" BeforeTargets="XamlPreCompile;CoreCompile" Outputs="@(Reference)">
-      <ItemGroup>
-          <Reference Remove="@(Reference)"
-              Condition="'%(Reference.Filename)%(Reference.Extension)' == 'Microsoft.Windows.UI.Xaml.dll'" />
-          <ReferencePathWithRefAssemblies Remove="@(ReferencePathWithRefAssemblies)"
-              Condition="'%(ReferencePathWithRefAssemblies.Filename)%(ReferencePathWithRefAssemblies.Extension)' == 'Microsoft.Windows.UI.Xaml.dll'" />
-          <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)"
-              Condition="'%(ReferenceCopyLocalPaths.Filename)%(ReferenceCopyLocalPaths.Extension)' == 'Microsoft.Windows.UI.Xaml.dll'" />
-          <ReferencePath Remove="@(ReferencePath)"
-              Condition="'%(ReferencePath.Filename)%(ReferencePath.Extension)' == 'Microsoft.Windows.UI.Xaml.dll'" />
-          <RuntimePackAsset Remove="@(RuntimePackAsset)"
-Condition="'%(RuntimePackAsset.Filename)%(RuntimePackAsset.Extension)' == 'Microsoft.Windows.UI.Xaml.dll'" />
-      </ItemGroup>
-  </Target>
 </Project>


### PR DESCRIPTION
This PR updates our tooling to use Microsoft.WindowsAppSDK 1.6-preview2 and removes prior workarounds only needed for preview1.

- **Update WindowsAppSDK to preview2**
- **Update WindowsSdkPackageVersion for net6 and net8**
- **Remove workaround for wasdk 1.6 < preview2**


Progress towards https://github.com/CommunityToolkit/Tooling-Windows-Submodule/issues/205