### PR TITLE
Update Microsoft.WindowsAppSDK to 1.6 stable

### DIFF
--- a/MultiTarget/PackageReferences/WinAppSdk.props
+++ b/MultiTarget/PackageReferences/WinAppSdk.props
@@ -2,7 +2,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.240829007" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
-    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2730-prerelease" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.1" />

--- a/MultiTarget/PackageReferences/WinAppSdk.props
+++ b/MultiTarget/PackageReferences/WinAppSdk.props
@@ -1,6 +1,6 @@
 <Project>
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.240821007-preview2" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.240829007" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
     <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2730-prerelease" />
   </ItemGroup>


### PR DESCRIPTION
This PR updates our tooling to use the recent Microsoft.WindowsAppSDK 1.6 stable release.
 
Progress towards https://github.com/CommunityToolkit/Tooling-Windows-Submodule/issues/205