### PR TITLE
Enabled CsWinRTAotWarningLevel 2

### DIFF
--- a/ToolkitComponent.SourceProject.props
+++ b/ToolkitComponent.SourceProject.props
@@ -17,6 +17,7 @@
 
   <PropertyGroup>
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
+    <CsWinRTAotWarningLevel Condition="'$(IsAotCompatible)' == 'true'">2</CsWinRTAotWarningLevel>
   </PropertyGroup>
 
   <!-- Auto Generate our own Assembly Info -->


### PR DESCRIPTION
Enables additional AoT analyzers by setting `CsWinRTAotWarningLevel` to 2, as suggested in https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/195#discussion_r1722185832.

Progress towards #205 