### PR TITLE
Fixed gallery crash under Wasdk 1.6

### DIFF
--- a/CommunityToolkit.App.Shared/Renderers/GeneratedSampleOptionsRenderer.xaml.cs
+++ b/CommunityToolkit.App.Shared/Renderers/GeneratedSampleOptionsRenderer.xaml.cs
@@ -30,14 +30,14 @@ public sealed partial class GeneratedSampleOptionsRenderer : UserControl
     /// The backing <see cref="DependencyProperty"/> for <see cref="SampleOptions"/>.
     /// </summary>
     public static readonly DependencyProperty SampleOptionsProperty =
-        DependencyProperty.Register(nameof(SampleOptions), typeof(List<IGeneratedToolkitSampleOptionViewModel>), typeof(GeneratedSampleOptionsRenderer), new PropertyMetadata(new List<IGeneratedToolkitSampleOptionViewModel>()));
+        DependencyProperty.Register(nameof(SampleOptions), typeof(IGeneratedToolkitSampleOptionViewModel[]), typeof(GeneratedSampleOptionsRenderer), new PropertyMetadata(new List<IGeneratedToolkitSampleOptionViewModel>()));
 
     /// <summary>
     /// The generated sample options that should be displayed to the user.
     /// </summary>
-    public List<IGeneratedToolkitSampleOptionViewModel> SampleOptions
+    public IGeneratedToolkitSampleOptionViewModel[] SampleOptions
     {
-        get => (List<IGeneratedToolkitSampleOptionViewModel>)GetValue(SampleOptionsProperty);
+        get => (IGeneratedToolkitSampleOptionViewModel[])GetValue(SampleOptionsProperty);
         set => SetValue(SampleOptionsProperty, value);
     }
 

--- a/CommunityToolkit.App.Shared/Renderers/GeneratedSampleOptionsRenderer.xaml.cs
+++ b/CommunityToolkit.App.Shared/Renderers/GeneratedSampleOptionsRenderer.xaml.cs
@@ -30,14 +30,14 @@ public sealed partial class GeneratedSampleOptionsRenderer : UserControl
     /// The backing <see cref="DependencyProperty"/> for <see cref="SampleOptions"/>.
     /// </summary>
     public static readonly DependencyProperty SampleOptionsProperty =
-        DependencyProperty.Register(nameof(SampleOptions), typeof(IEnumerable<IGeneratedToolkitSampleOptionViewModel>), typeof(GeneratedSampleOptionsRenderer), new PropertyMetadata(null));
+        DependencyProperty.Register(nameof(SampleOptions), typeof(List<IGeneratedToolkitSampleOptionViewModel>), typeof(GeneratedSampleOptionsRenderer), new PropertyMetadata(new List<IGeneratedToolkitSampleOptionViewModel>()));
 
     /// <summary>
     /// The generated sample options that should be displayed to the user.
     /// </summary>
-    public IEnumerable<IGeneratedToolkitSampleOptionViewModel>? SampleOptions
+    public List<IGeneratedToolkitSampleOptionViewModel> SampleOptions
     {
-        get => (IEnumerable<IGeneratedToolkitSampleOptionViewModel>?)GetValue(SampleOptionsProperty);
+        get => (List<IGeneratedToolkitSampleOptionViewModel>)GetValue(SampleOptionsProperty);
         set => SetValue(SampleOptionsProperty, value);
     }
 

--- a/CommunityToolkit.App.Shared/Renderers/ToolkitSampleRenderer.xaml.cs
+++ b/CommunityToolkit.App.Shared/Renderers/ToolkitSampleRenderer.xaml.cs
@@ -197,7 +197,7 @@ public sealed partial class ToolkitSampleRenderer : Page
             {
                 SampleOptionsPaneInstance = new GeneratedSampleOptionsRenderer
                 {
-                    SampleOptions = propertyContainer.GeneratedPropertyMetadata.ToList()
+                    SampleOptions = propertyContainer.GeneratedPropertyMetadata
                 };
             }
         }

--- a/CommunityToolkit.App.Shared/Renderers/ToolkitSampleRenderer.xaml.cs
+++ b/CommunityToolkit.App.Shared/Renderers/ToolkitSampleRenderer.xaml.cs
@@ -193,10 +193,13 @@ public sealed partial class ToolkitSampleRenderer : Page
             // Generated properties reference these in getters and setters.
             propertyContainer.GeneratedPropertyMetadata = Metadata.GeneratedSampleOptions;
 
-            SampleOptionsPaneInstance = new GeneratedSampleOptionsRenderer
+            if (propertyContainer.GeneratedPropertyMetadata is not null)
             {
-                SampleOptions = propertyContainer.GeneratedPropertyMetadata
-            };
+                SampleOptionsPaneInstance = new GeneratedSampleOptionsRenderer
+                {
+                    SampleOptions = propertyContainer.GeneratedPropertyMetadata.ToList()
+                };
+            }
         }
         else
         {

--- a/CommunityToolkit.Tooling.SampleGen/Metadata/IToolkitSampleGeneratedOptionPropertyContainer.cs
+++ b/CommunityToolkit.Tooling.SampleGen/Metadata/IToolkitSampleGeneratedOptionPropertyContainer.cs
@@ -16,5 +16,5 @@ public interface IToolkitSampleGeneratedOptionPropertyContainer
     /// as a proxy between the current actual value and the
     /// generated properties which consume them.
     /// </summary>
-    public IEnumerable<IGeneratedToolkitSampleOptionViewModel>? GeneratedPropertyMetadata { get; set; }
+    public IGeneratedToolkitSampleOptionViewModel[]? GeneratedPropertyMetadata { get; set; }
 }

--- a/CommunityToolkit.Tooling.SampleGen/Metadata/ToolkitSampleMetadata.cs
+++ b/CommunityToolkit.Tooling.SampleGen/Metadata/ToolkitSampleMetadata.cs
@@ -50,7 +50,7 @@ public sealed class ToolkitSampleMetadata
     /// <summary>
     /// Gets or sets the generated sample options that were declared alongside this sample, if any.
     /// </summary>
-    public IEnumerable<IGeneratedToolkitSampleOptionViewModel>? GeneratedSampleOptions { get; set; }
+    public IGeneratedToolkitSampleOptionViewModel[]? GeneratedSampleOptions { get; set; }
 
     /// <summary>
     /// Contains the metadata needed to identify and display a toolkit sample.
@@ -74,7 +74,7 @@ public sealed class ToolkitSampleMetadata
         Func<object> sampleControlFactory,
         Type? sampleOptionsPaneType = null,
         Func<object, object>? sampleOptionsPaneFactory = null,
-        IEnumerable<IGeneratedToolkitSampleOptionViewModel>? generatedSampleOptions = null)
+        IGeneratedToolkitSampleOptionViewModel[]? generatedSampleOptions = null)
     {
         Id = id;
         DisplayName = displayName;

--- a/CommunityToolkit.Tooling.SampleGen/ToolkitSampleOptionGenerator.cs
+++ b/CommunityToolkit.Tooling.SampleGen/ToolkitSampleOptionGenerator.cs
@@ -126,9 +126,9 @@ namespace {attachedSymbol.ContainingNamespace}
 {{
     public partial class {attachedSymbol.Name} : {typeof(IToolkitSampleGeneratedOptionPropertyContainer).Namespace}.{nameof(IToolkitSampleGeneratedOptionPropertyContainer)}
     {{
-        private IEnumerable<{typeof(IGeneratedToolkitSampleOptionViewModel).FullName}>? _generatedPropertyMetadata;
+        private {typeof(IGeneratedToolkitSampleOptionViewModel).FullName}[]? _generatedPropertyMetadata;
 
-        public IEnumerable<{typeof(IGeneratedToolkitSampleOptionViewModel).FullName}>? GeneratedPropertyMetadata
+        public {typeof(IGeneratedToolkitSampleOptionViewModel).FullName}[]? GeneratedPropertyMetadata
         {{
             get => _generatedPropertyMetadata;
             set


### PR DESCRIPTION
Fixed a runtime binding exception in wasdk gallery samples where the generated options pane is used.

Closes #213