### PR TITLE
Fix #215 - Extra webview2 dll in nuget package

### DIFF
--- a/MultiTarget/PackageReferences/WinAppSdk.props
+++ b/MultiTarget/PackageReferences/WinAppSdk.props
@@ -2,7 +2,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.240829007" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
-    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2792.45" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2792.45" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.1" />

--- a/MultiTarget/PackageReferences/WinAppSdk.props
+++ b/MultiTarget/PackageReferences/WinAppSdk.props
@@ -2,6 +2,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.240829007" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2792.45" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.1" />

--- a/MultiTarget/WinUI.Extra.props
+++ b/MultiTarget/WinUI.Extra.props
@@ -36,6 +36,9 @@
 
     <WindowsSdkPackageVersion Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 8">10.0.22621.41</WindowsSdkPackageVersion>
     <WindowsSdkPackageVersion Condition="8 > $([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)'))">10.0.22621.38</WindowsSdkPackageVersion>
+
+    <!--- Workaround for ADO 53865998 - See https://github.com/CommunityToolkit/Tooling-Windows-Submodule/issues/215 - Don't include extraneous WebView2 dll -->
+    <WebView2NeverCopyLoaderDllToOutputDirectory Condition="'$(WebView2NeverCopyLoaderDllToOutputDirectory)' == '' And '$(WebView2EnableCsWinRTProjection)' == 'true'">true</WebView2NeverCopyLoaderDllToOutputDirectory>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsUno)' == 'true'">

--- a/MultiTarget/WinUI.Extra.props
+++ b/MultiTarget/WinUI.Extra.props
@@ -38,7 +38,7 @@
     <WindowsSdkPackageVersion Condition="8 > $([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)'))">10.0.22621.38</WindowsSdkPackageVersion>
 
     <!--- Workaround for ADO 53865998 - See https://github.com/CommunityToolkit/Tooling-Windows-Submodule/issues/215 - Don't include extraneous WebView2 dll -->
-    <WebView2NeverCopyLoaderDllToOutputDirectory Condition="'$(WebView2NeverCopyLoaderDllToOutputDirectory)' == '' And '$(WebView2EnableCsWinRTProjection)' == 'true'">true</WebView2NeverCopyLoaderDllToOutputDirectory>
+    <WebView2NeverCopyLoaderDllToOutputDirectory>true</WebView2NeverCopyLoaderDllToOutputDirectory>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsUno)' == 'true'">


### PR DESCRIPTION
Remove webview2loader.dll from package (hopefully) - test workaround to report back to platform.

Fixes #215 

Going to open a Windows PR using this to see if it resolves the issue or not.