### PR TITLE
Conditionally reference WinAppSDK packages from HasWinUI prop

### DIFF
--- a/MultiTarget/PackageReferences/WinAppSdk.props
+++ b/MultiTarget/PackageReferences/WinAppSdk.props
@@ -1,10 +1,10 @@
 <Project>
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.240829007" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
-    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2792.45" PrivateAssets="all" />
+    <PackageReference Condition="'$(HasWinUI)' == 'true'" Include="Microsoft.WindowsAppSDK" Version="1.6.240829007" />
+    <PackageReference Condition="'$(HasWinUI)' == 'true'" Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
+    <PackageReference Condition="'$(HasWinUI)' == 'true'" Include="Microsoft.Web.WebView2" Version="1.0.2792.45" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.1.1" />
+    <PackageReference Condition="'$(HasWinUI)' == 'true'" Include="Microsoft.Windows.CsWinRT" Version="2.1.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This pull request includes changes to the `MultiTarget/PackageReferences/WinAppSdk.props` file to conditionally include package references based on the `HasWinUI` property.


Needed by https://github.com/CommunityToolkit/Labs-Windows/pull/579