### PR TITLE
Enable TFM overrides per MultiTarget

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ on:
 
 env:
   DOTNET_VERSION: ${{ '8.0.x' }}
-  ENABLE_DIAGNOSTICS: false
+  ENABLE_DIAGNOSTICS: true
   #COREHOST_TRACE: 1
   COREHOST_TRACEFILE: corehosttrace.log
 
@@ -285,11 +285,10 @@ jobs:
         working-directory: ./
         run: ./tooling/GenerateAllSolution.ps1${{ env.ENABLE_DIAGNOSTICS == 'true' && ' -UseDiagnostics' || '' }} -MultiTargets wasm
 
-      # Issue with Comment Links currently, see: https://github.com/mrlacey/CommentLinks/issues/38
-      # See launch.json configuration file for analogous command we're emulating here to build LINK: ../../.vscode/launch.json:CommunityToolkit.App.Wasm.csproj
       - name: dotnet build
-        working-directory: ./${{ env.HEADS_DIRECTORY }}/AllComponents/Wasm/
-        run: dotnet build /r /bl /p:UnoSourceGeneratorUseGenerationHost=true /p:UnoSourceGeneratorUseGenerationController=false
+        shell: pwsh
+        working-directory: ./
+        run: ./tooling/Build-Toolkit-Components.ps1 -Release -MultiTargets wasm ${{ env.ENABLE_DIAGNOSTICS == 'true' && ' -BinlogOutput ./ -EnableBinLogs' || '' }}
   
       # TODO: Do we want to run tests here? Can we do that on linux easily?
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -283,7 +283,7 @@ jobs:
       - name: Generate solution
         shell: pwsh
         working-directory: ./
-        run: ./tooling/GenerateAllSolution.ps1${{ env.ENABLE_DIAGNOSTICS == 'true' && ' -UseDiagnostics' || '' }}
+        run: ./tooling/GenerateAllSolution.ps1${{ env.ENABLE_DIAGNOSTICS == 'true' && ' -UseDiagnostics' || '' }} -MultiTargets wasm
 
       # Issue with Comment Links currently, see: https://github.com/mrlacey/CommentLinks/issues/38
       # See launch.json configuration file for analogous command we're emulating here to build LINK: ../../.vscode/launch.json:CommunityToolkit.App.Wasm.csproj

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ on:
 
 env:
   DOTNET_VERSION: ${{ '8.0.x' }}
-  ENABLE_DIAGNOSTICS: true
+  ENABLE_DIAGNOSTICS: false
   #COREHOST_TRACE: 1
   COREHOST_TRACEFILE: corehosttrace.log
 

--- a/Build-Toolkit-Components.ps1
+++ b/Build-Toolkit-Components.ps1
@@ -124,7 +124,21 @@ function Invoke-MSBuildWithBinlog {
     )
 
     # Reset build args to default
-    $msbuildArgs = @("-r", "-m", "/p:DebugType=Portable")
+    $msbuildArgs = @("/p:DebugType=Portable")
+
+    # Add "-r" parameter if not running on linux
+    if ($($PSVersionTable.Platform) -ne "Unix") {
+        $msbuildArgs += "-r"
+    }
+    # Otherwise, add "-restore" parameter
+    else {
+        $msbuildArgs += "-restore"
+    }
+
+    # Add "-m" parameter if not running on linux
+    if ($($PSVersionTable.Platform) -ne "Unix") {
+        $msbuildArgs += "-m"
+    }
 
     # Add packing to the msbuild arguments if NupkgOutput is supplied
     if ($NupkgOutput) {

--- a/Build-Toolkit-Components.ps1
+++ b/Build-Toolkit-Components.ps1
@@ -170,7 +170,13 @@ function Invoke-MSBuildWithBinlog {
         $msbuildArgs += "/v:detailed"
     }
 
-    msbuild $msbuildArgs $TargetHeadPath
+    # If platform is linux, use dotnet instead of msbuild
+    if ($($PSVersionTable.Platform) -eq "Unix") {
+        dotnet build $msbuildArgs $TargetHeadPath
+    }
+    else {
+        msbuild $msbuildArgs $TargetHeadPath
+    }
 }
 
 # Components are built individually

--- a/MultiTarget/AvailableTargetFrameworks.props
+++ b/MultiTarget/AvailableTargetFrameworks.props
@@ -1,23 +1,23 @@
 <Project>
     <PropertyGroup>
-        <UwpTargetFramework>uap10.0.17763</UwpTargetFramework>
-        <WinAppSdkTargetFramework>net8.0-windows10.0.22621.0;net7.0-windows10.0.22621.0;net6.0-windows10.0.22621.0;</WinAppSdkTargetFramework>
+        <UwpTargetFramework Condition="'$(UwpTargetFramework)' == ''">uap10.0.17763</UwpTargetFramework>
+        <WinAppSdkTargetFramework Condition="'$(WinAppSdkTargetFramework)' == ''">net8.0-windows10.0.22621.0;net7.0-windows10.0.22621.0;net6.0-windows10.0.22621.0;</WinAppSdkTargetFramework>
         
-        <WasmHeadTargetFramework>net8.0</WasmHeadTargetFramework>
-        <LinuxHeadTargetFramework>net8.0</LinuxHeadTargetFramework>
-        <WpfHeadTargetFramework>net8.0</WpfHeadTargetFramework>
+        <WasmHeadTargetFramework Condition="'$(WasmHeadTargetFramework)' == ''">net8.0</WasmHeadTargetFramework>
+        <LinuxHeadTargetFramework Condition="'$(LinuxHeadTargetFramework)' == ''">net8.0</LinuxHeadTargetFramework>
+        <WpfHeadTargetFramework Condition="'$(WpfHeadTargetFramework)' == ''">net8.0</WpfHeadTargetFramework>
         
-        <AndroidLibTargetFramework>net8.0-android34.0</AndroidLibTargetFramework>
-        <MacOSLibTargetFramework>net8.0-maccatalyst</MacOSLibTargetFramework>
-        <iOSLibTargetFramework>net8.0-ios</iOSLibTargetFramework>
+        <AndroidLibTargetFramework Condition="'$(AndroidLibTargetFramework)' == ''">net8.0-android34.0</AndroidLibTargetFramework>
+        <MacOSLibTargetFramework Condition="'$(MacOSLibTargetFramework)' == ''">net8.0-maccatalyst</MacOSLibTargetFramework>
+        <iOSLibTargetFramework Condition="'$(iOSLibTargetFramework)' == ''">net8.0-ios</iOSLibTargetFramework>
 
         <!-- Used for comparison to current TargetFramework -->
-        <LinuxLibTargetFramework>net8.0</LinuxLibTargetFramework>
-        <WasmLibTargetFramework>net8.0</WasmLibTargetFramework>
-        <WpfLibTargetFramework>net8.0</WpfLibTargetFramework>
+        <LinuxLibTargetFramework Condition="'$(LinuxLibTargetFramework)' == ''">net8.0</LinuxLibTargetFramework>
+        <WasmLibTargetFramework Condition="'$(WasmLibTargetFramework)' == ''">net8.0</WasmLibTargetFramework>
+        <WpfLibTargetFramework Condition="'$(WpfLibTargetFramework)' == ''">net8.0</WpfLibTargetFramework>
 
         <!-- Used for defining TargetFramework under platforms that need it -->
-        <DotnetStandardCommonTargetFramework>netstandard2.0</DotnetStandardCommonTargetFramework>
-        <DotnetCommonTargetFramework>net8.0</DotnetCommonTargetFramework>
+        <DotnetStandardCommonTargetFramework Condition="'$(DotnetStandardCommonTargetFramework)' == ''">netstandard2.0</DotnetStandardCommonTargetFramework>
+        <DotnetCommonTargetFramework Condition="'$(DotnetCommonTargetFramework)' == ''">net8.0</DotnetCommonTargetFramework>
     </PropertyGroup>
 </Project>

--- a/MultiTarget/EnabledTargetFrameworks.props
+++ b/MultiTarget/EnabledTargetFrameworks.props
@@ -1,23 +1,23 @@
 <Project>
     <PropertyGroup>
-        <UwpTargetFramework>uap10.0.17763</UwpTargetFramework>
-        <WinAppSdkTargetFramework>net8.0-windows10.0.22621.0;net7.0-windows10.0.22621.0;net6.0-windows10.0.22621.0;</WinAppSdkTargetFramework>
+        <UwpTargetFramework Condition="'$(UwpTargetFramework)' == ''">uap10.0.17763</UwpTargetFramework>
+        <WinAppSdkTargetFramework Condition="'$(WinAppSdkTargetFramework)' == ''">net8.0-windows10.0.22621.0;net7.0-windows10.0.22621.0;net6.0-windows10.0.22621.0;</WinAppSdkTargetFramework>
         
-        <WasmHeadTargetFramework>net8.0</WasmHeadTargetFramework>
-        <LinuxHeadTargetFramework>net8.0</LinuxHeadTargetFramework>
-        <WpfHeadTargetFramework>net8.0</WpfHeadTargetFramework>
-        
-        
+        <WasmHeadTargetFramework Condition="'$(WasmHeadTargetFramework)' == ''">net8.0</WasmHeadTargetFramework>
+        <LinuxHeadTargetFramework Condition="'$(LinuxHeadTargetFramework)' == ''">net8.0</LinuxHeadTargetFramework>
+        <WpfHeadTargetFramework Condition="'$(WpfHeadTargetFramework)' == ''">net8.0</WpfHeadTargetFramework>
         
         
-
+        
+        
+        
         <!-- Used for comparison to current TargetFramework -->
-        <LinuxLibTargetFramework>net8.0</LinuxLibTargetFramework>
-        <WasmLibTargetFramework>net8.0</WasmLibTargetFramework>
-        <WpfLibTargetFramework>net8.0</WpfLibTargetFramework>
+        <LinuxLibTargetFramework Condition="'$(LinuxLibTargetFramework)' == ''">net8.0</LinuxLibTargetFramework>
+        <WasmLibTargetFramework Condition="'$(WasmLibTargetFramework)' == ''">net8.0</WasmLibTargetFramework>
+        <WpfLibTargetFramework Condition="'$(WpfLibTargetFramework)' == ''">net8.0</WpfLibTargetFramework>
 
         <!-- Used for defining TargetFramework under platforms that need it -->
-        <DotnetStandardCommonTargetFramework>netstandard2.0</DotnetStandardCommonTargetFramework>
-        <DotnetCommonTargetFramework>net8.0</DotnetCommonTargetFramework>
+        <DotnetStandardCommonTargetFramework Condition="'$(DotnetStandardCommonTargetFramework)' == ''">netstandard2.0</DotnetStandardCommonTargetFramework>
+        <DotnetCommonTargetFramework Condition="'$(DotnetCommonTargetFramework)' == ''">net8.0</DotnetCommonTargetFramework>
     </PropertyGroup>
 </Project>

--- a/MultiTarget/UseTargetFrameworks.ps1
+++ b/MultiTarget/UseTargetFrameworks.ps1
@@ -107,7 +107,7 @@ $targetFrameworksToRemove = @(
 
 $targetFrameworksToRemoveRegexPartial = $targetFrameworksToRemove -join "|";
 
-$newFileContents = $fileContents -replace "<(?:$targetFrameworksToRemoveRegexPartial)>.+?>", '';
+$newFileContents = $fileContents -replace "<(?:$targetFrameworksToRemoveRegexPartial).+?>.+?>", '';
 
 Set-Content -Force -Path $PSScriptRoot/EnabledTargetFrameworks.props -Value $newFileContents;
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.201",
+    "version": "8.0.403",
     "rollForward": "latestFeature"
   },
   "msbuild-sdks": 


### PR DESCRIPTION
This PR adds conditions to the default declared TFMs for MultiTargets, enabling per-project TFM overrides without losing existing compatability with features that rely on MultiTarget declarations. 