### PR TITLE
Revert WinAppSdkTargetFramework version from 22621 to 19041.

### DIFF
--- a/MultiTarget/AvailableTargetFrameworks.props
+++ b/MultiTarget/AvailableTargetFrameworks.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
         <UwpTargetFramework Condition="'$(UwpTargetFramework)' == ''">uap10.0.17763</UwpTargetFramework>
-        <WinAppSdkTargetFramework Condition="'$(WinAppSdkTargetFramework)' == ''">net8.0-windows10.0.22621.0;net7.0-windows10.0.22621.0;net6.0-windows10.0.22621.0;</WinAppSdkTargetFramework>
+        <WinAppSdkTargetFramework Condition="'$(WinAppSdkTargetFramework)' == ''">net8.0-windows10.0.19041.0;net7.0-windows10.0.19041.0;net6.0-windows10.0.19041.0;</WinAppSdkTargetFramework>
         
         <WasmHeadTargetFramework Condition="'$(WasmHeadTargetFramework)' == ''">net8.0</WasmHeadTargetFramework>
         <LinuxHeadTargetFramework Condition="'$(LinuxHeadTargetFramework)' == ''">net8.0</LinuxHeadTargetFramework>

--- a/MultiTarget/EnabledTargetFrameworks.props
+++ b/MultiTarget/EnabledTargetFrameworks.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
         <UwpTargetFramework Condition="'$(UwpTargetFramework)' == ''">uap10.0.17763</UwpTargetFramework>
-        <WinAppSdkTargetFramework Condition="'$(WinAppSdkTargetFramework)' == ''">net8.0-windows10.0.22621.0;net7.0-windows10.0.22621.0;net6.0-windows10.0.22621.0;</WinAppSdkTargetFramework>
+        <WinAppSdkTargetFramework Condition="'$(WinAppSdkTargetFramework)' == ''">net8.0-windows10.0.19041.0;net7.0-windows10.0.19041.0;net6.0-windows10.0.19041.0;</WinAppSdkTargetFramework>
         
         <WasmHeadTargetFramework Condition="'$(WasmHeadTargetFramework)' == ''">net8.0</WasmHeadTargetFramework>
         <LinuxHeadTargetFramework Condition="'$(LinuxHeadTargetFramework)' == ''">net8.0</LinuxHeadTargetFramework>


### PR DESCRIPTION
Prerequisite PR https://github.com/CommunityToolkit/Windows/pull/540

Since Win2d 1.1.1 was the reason we originally bumped our Windows App SDK TFM to 22621 (see https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/161, https://github.com/microsoft/Win2D/issues/943) and 1.3.0 has reverted to 19041, we can reduce our TFM back down to 19041. 