### PR TITLE
Cleanup of WindowsAppSDK implicit properties and project references 

### DIFF
--- a/MultiTarget/PackageReferences/WinAppSdk.props
+++ b/MultiTarget/PackageReferences/WinAppSdk.props
@@ -1,10 +1,6 @@
 <Project>
   <ItemGroup>
     <PackageReference Condition="'$(HasWinUI)' == 'true'" Include="Microsoft.WindowsAppSDK" Version="1.6.240829007" />
-    <PackageReference Condition="'$(HasWinUI)' == 'true'" Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
     <PackageReference Condition="'$(HasWinUI)' == 'true'" Include="Microsoft.Web.WebView2" Version="1.0.2792.45" PrivateAssets="all" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Condition="'$(HasWinUI)' == 'true'" Include="Microsoft.Windows.CsWinRT" Version="2.1.1" />
   </ItemGroup>
 </Project>

--- a/MultiTarget/WinUI.Extra.props
+++ b/MultiTarget/WinUI.Extra.props
@@ -34,9 +34,6 @@
     <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 8">win-x86;win-x64;win-arm64</RuntimeIdentifiers> 
     <RuntimeIdentifiers Condition="8 > $([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)'))">win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
 
-    <WindowsSdkPackageVersion Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 8">10.0.22621.41</WindowsSdkPackageVersion>
-    <WindowsSdkPackageVersion Condition="8 > $([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)'))">10.0.22621.38</WindowsSdkPackageVersion>
-
     <!--- Workaround for ADO 53865998 - See https://github.com/CommunityToolkit/Tooling-Windows-Submodule/issues/215 - Don't include extraneous WebView2 dll -->
     <WebView2NeverCopyLoaderDllToOutputDirectory>true</WebView2NeverCopyLoaderDllToOutputDirectory>
   </PropertyGroup>


### PR DESCRIPTION
Cleans up unnecessary explicit declaration of
- The package reference `Microsoft.Windows.SDK.BuildTools`, as the same version comes from `Microsoft.WindowsAppSdk` via a transitive nuget reference.
- The package reference `Microsoft.Windows.CsWinRT`, since the CsWinRT analyzers and .dll are inside the runtime pack for the Windows SDK.
- The property `WindowsSdkPackageVersion`, since this is set automatically by the underlying SDK when running dotnet 8.0.403 or later. 

Follow up to https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/217#discussion_r1813745206 and https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/217#discussion_r1813744249, closes #219.