### PR TITLE
Update Microsoft.WindowsAppSDK version in WinAppSdk.props

### DIFF
--- a/MultiTarget/PackageReferences/WinAppSdk.props
+++ b/MultiTarget/PackageReferences/WinAppSdk.props
@@ -1,6 +1,6 @@
 <Project>
   <ItemGroup>
-    <PackageReference Condition="'$(HasWinUI)' == 'true'" Include="Microsoft.WindowsAppSDK" Version="1.6.240829007" />
+    <PackageReference Condition="'$(HasWinUI)' == 'true'" Include="Microsoft.WindowsAppSDK" Version="1.6.240923002" />
     <PackageReference Condition="'$(HasWinUI)' == 'true'" Include="Microsoft.Web.WebView2" Version="1.0.2792.45" PrivateAssets="all" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR fixes a package downgrade warning when the latest Win2d packages are used:
```
"C:\a\Windows\Windows\CommunityToolkit.AllComponents.sln" (Restore target) (1) ->
       (Restore target) -> 
         C:\a\Windows\Windows\components\ImageCropper\samples\ImageCropper.Samples.csproj : error NU1605: Warning As Error: Detected package downgrade: Microsoft.WindowsAppSDK from 1.6.240923002 to 1.6.240829007. Reference the package directly from the project to select a different version.  [C:\a\Windows\Windows\CommunityToolkit.AllComponents.sln]
       C:\a\Windows\Windows\components\ImageCropper\samples\ImageCropper.Samples.csproj : error NU1605:  ImageCropperExperiment.Samples -> CommunityToolkit.WinUI.Controls.ImageCropper -> Microsoft.Graphics.Win2D 1.3.0 -> Microsoft.WindowsAppSDK (>= 1.6.240923002)  [C:\a\Windows\Windows\CommunityToolkit.AllComponents.sln]
       C:\a\Windows\Windows\components\ImageCropper\samples\ImageCropper.Samples.csproj : error NU1605:  ImageCropperExperiment.Samples -> Microsoft.WindowsAppSDK (>= 1.6.240829007) [C:\a\Windows\Windows\CommunityToolkit.AllComponents.sln]
```

See also https://github.com/CommunityToolkit/Windows/actions/runs/11523058494/job/32088060877#step:11:3515

