### PR TITLE
Enable AllowUnsafeBlocks for Gallery and Test heads under Windows App SDK

### DIFF
--- a/ProjectHeads/Head.WinAppSdk.props
+++ b/ProjectHeads/Head.WinAppSdk.props
@@ -9,6 +9,7 @@
     <EnableMsixTooling>true</EnableMsixTooling>
     <WindowsAppContainer>true</WindowsAppContainer>
     <ApplicationManifest>app.manifest</ApplicationManifest>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)\..\MultiTarget\PackageReferences\WinAppSdk.props" />


### PR DESCRIPTION
This PR fixes the error annotations in the Gallery head when running the latest WindowsAppSDK and CsWinRT:
```
build (3, wasdk): tooling/ProjectHeads/AllComponents/Wasdk/obj/x64/Release/net8.0-windows10.0.19041.0/win-x64/Styles/ItemTemplates.g.i.cs#L13
Type 'ItemTemplates' implements generic WinRT interfaces which requires generated code using unsafe for trimming and AOT compatibility if passed across the WinRT ABI.
Project needs to be updated with '<AllowUnsafeBlocks>true</AllowUnsafeBlocks>'. 
```

See https://github.com/CommunityToolkit/Labs-Windows/actions/runs/11560414170