### PR TITLE
Fixed a regex issue with UseTargetFrameworks.ps1 when enabling 'all'

### DIFF
--- a/MultiTarget/UseTargetFrameworks.ps1
+++ b/MultiTarget/UseTargetFrameworks.ps1
@@ -42,6 +42,7 @@ $DroidTfm = "AndroidLibTargetFramework";
 $NetstandardTfm = "DotnetStandardCommonTargetFramework";
 
 $fileContents = Get-Content -Path $PSScriptRoot/AvailableTargetFrameworks.props
+$newFileContents = $fileContents;
 
 # 'all' represents many '$MultiTargets' values
 if ($MultiTargets.Contains("all")) {
@@ -105,10 +106,12 @@ $targetFrameworksToRemove = @(
     $NetstandardTfm
 ).Where({ -not $desiredTfmValues.Contains($_) })
 
-$targetFrameworksToRemoveRegexPartial = $targetFrameworksToRemove -join "|";
-
-$newFileContents = $fileContents -replace "<(?:$targetFrameworksToRemoveRegexPartial).+?>.+?>", '';
+# When targetFrameworksToRemoveRegexPartial is empty, the regex will match everything.
+# To work around this, check if there's anything to remove before doing it.
+if ($targetFrameworksToRemove.Length -gt 0) {
+    $targetFrameworksToRemoveRegexPartial = "$($targetFrameworksToRemove -join "|")";
+    $newFileContents = $fileContents -replace "<(?:$targetFrameworksToRemoveRegexPartial).+?>.+?>", '';
+}
 
 Set-Content -Force -Path $PSScriptRoot/EnabledTargetFrameworks.props -Value $newFileContents;
-
 Write-Output "Done. Please close and regenerate your solution. Do not commit these changes to the tooling repository."


### PR DESCRIPTION
This PR fixes an issue with our `UseTargetFrameworks.ps1` script where TFMs would get disabled instead of enabled when 'all' MultiTargets are requested.
 
Follow-up to https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/218
Unblocks https://github.com/CommunityToolkit/Labs-Windows/actions/runs/11564402747/job/32190626530