### PR TITLE
Upgrade to .NET 9.0

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "uno.check": {
-      "version": "1.20.2",
+      "version": "1.27.1",
       "commands": [
         "uno-check"
       ]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,5 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.208.0/containers/dotnet/.devcontainer/base.Dockerfile
-
-# [Choice] .NET version: 6.0, 5.0, 3.1, 6.0-bullseye, 5.0-bullseye, 3.1-bullseye, 6.0-focal, 5.0-focal, 3.1-focal
-ARG VARIANT="6.0-bullseye-slim"
-FROM mcr.microsoft.com/vscode/devcontainers/dotnet:0-${VARIANT}
+# See https://github.com/devcontainers/images/tree/main/src/dotnet for image choices
+FROM mcr.microsoft.com/vscode/devcontainers/dotnet:9.0
 
 # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="none"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
 		"args": {
 			// Update 'VARIANT' to pick a .NET Core version: 3.1, 5.0, 6.0
 			// Append -bullseye or -focal to pin to an OS version.
-			"VARIANT": "8.0",
+			"VARIANT": "9.0",
 			// Options
 			"NODE_VERSION": "lts/*"
 		}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
 
 env:
-  DOTNET_VERSION: ${{ '8.0.x' }}
+  DOTNET_VERSION: ${{ '9.0.x' }}
   ENABLE_DIAGNOSTICS: false
   #COREHOST_TRACE: 1
   COREHOST_TRACEFILE: corehosttrace.log

--- a/Build-Toolkit-Components.ps1
+++ b/Build-Toolkit-Components.ps1
@@ -104,6 +104,20 @@ if ($null -eq $ExcludeMultiTargets)
     $ExcludeMultiTargets = @()
 }
 
+# Both uwp and wasdk share a targetframework. Both cannot be enabled at once.
+# If both are supplied, remove one based on WinUIMajorVersion.
+if ($MultiTargets.Contains('uwp') -and $MultiTargets.Contains('wasdk'))
+{
+    if ($WinUIMajorVersion -eq 2)
+    {
+        $ExcludeMultiTargets = $ExcludeMultiTargets + 'wasdk'
+    }
+    else
+    {
+        $ExcludeMultiTargets = $ExcludeMultiTargets + 'uwp'
+    }
+}
+
 $MultiTargets = $MultiTargets | Where-Object { $_ -notin $ExcludeMultiTargets }
 
 if ($Components -eq @('all')) {

--- a/Build-Toolkit-Gallery.ps1
+++ b/Build-Toolkit-Gallery.ps1
@@ -87,6 +87,20 @@ if ($null -eq $ExcludeMultiTargets)
   $ExcludeMultiTargets = @()
 }
 
+# Both uwp and wasdk share a targetframework. Both cannot be enabled at once.
+# If both are supplied, remove one based on WinUIMajorVersion.
+if ($MultiTargets.Contains('uwp') -and $MultiTargets.Contains('wasdk'))
+{
+    if ($WinUIMajorVersion -eq 2)
+    {
+        $ExcludeMultiTargets = $ExcludeMultiTargets + 'wasdk'
+    }
+    else
+    {
+        $ExcludeMultiTargets = $ExcludeMultiTargets + 'uwp'
+    }
+}
+
 if ($MultiTargets -eq 'all') {
   $MultiTargets = @('wasm', 'uwp', 'wasdk', 'wpf', 'linuxgtk', 'macos', 'ios', 'android', 'netstandard')
 }

--- a/CommunityToolkit.Tooling.SampleGen.Tests/CommunityToolkit.Tooling.SampleGen.Tests.csproj
+++ b/CommunityToolkit.Tooling.SampleGen.Tests/CommunityToolkit.Tooling.SampleGen.Tests.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.6.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.6.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CommunityToolkit.Tooling.TestGen.Tests/CommunityToolkit.Tooling.TestGen.Tests.csproj
+++ b/CommunityToolkit.Tooling.TestGen.Tests/CommunityToolkit.Tooling.TestGen.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />

--- a/GenerateAllSolution.ps1
+++ b/GenerateAllSolution.ps1
@@ -62,6 +62,20 @@ if ($null -eq $ExcludeMultiTargets)
     $ExcludeMultiTargets = @()
 }
 
+# Both uwp and wasdk share a targetframework. Both cannot be enabled at once.
+# If both are supplied, remove one based on WinUIMajorVersion.
+if ($MultiTargets.Contains('uwp') -and $MultiTargets.Contains('wasdk'))
+{
+    if ($WinUIMajorVersion -eq 2)
+    {
+        $ExcludeMultiTargets = $ExcludeMultiTargets + 'wasdk'
+    }
+    else
+    {
+        $ExcludeMultiTargets = $ExcludeMultiTargets + 'uwp'
+    }
+}
+
 $MultiTargets = $MultiTargets | Where-Object { $_ -notin $ExcludeMultiTargets }
 
 # Generate required props for "All" solution.

--- a/MultiTarget/AvailableTargetFrameworks.props
+++ b/MultiTarget/AvailableTargetFrameworks.props
@@ -3,21 +3,21 @@
         <UwpTargetFramework Condition="'$(UwpTargetFramework)' == ''">uap10.0.17763</UwpTargetFramework>
         <WinAppSdkTargetFramework Condition="'$(WinAppSdkTargetFramework)' == ''">net9.0-windows10.0.19041.0;net8.0-windows10.0.19041.0;net7.0-windows10.0.19041.0;net6.0-windows10.0.19041.0;</WinAppSdkTargetFramework>
         
-        <WasmHeadTargetFramework Condition="'$(WasmHeadTargetFramework)' == ''">net8.0;net9.0;</WasmHeadTargetFramework>
-        <LinuxHeadTargetFramework Condition="'$(LinuxHeadTargetFramework)' == ''">net8.0;net9.0;</LinuxHeadTargetFramework>
-        <WpfHeadTargetFramework Condition="'$(WpfHeadTargetFramework)' == ''">net8.0;net9.0;</WpfHeadTargetFramework>
+        <WasmHeadTargetFramework Condition="'$(WasmHeadTargetFramework)' == ''">net9.0;</WasmHeadTargetFramework>
+        <LinuxHeadTargetFramework Condition="'$(LinuxHeadTargetFramework)' == ''">net9.0;</LinuxHeadTargetFramework>
+        <WpfHeadTargetFramework Condition="'$(WpfHeadTargetFramework)' == ''">net9.0;</WpfHeadTargetFramework>
         
-        <AndroidLibTargetFramework Condition="'$(AndroidLibTargetFramework)' == ''">net8.0-android34.0;net9.0-android;</AndroidLibTargetFramework>
-        <MacOSLibTargetFramework Condition="'$(MacOSLibTargetFramework)' == ''">net8.0-maccatalyst;net9.0-maccatalyst;</MacOSLibTargetFramework>
-        <iOSLibTargetFramework Condition="'$(iOSLibTargetFramework)' == ''">net8.0-ios;net9.0-ios;</iOSLibTargetFramework>
+        <AndroidLibTargetFramework Condition="'$(AndroidLibTargetFramework)' == ''">net9.0-android;</AndroidLibTargetFramework>
+        <MacOSLibTargetFramework Condition="'$(MacOSLibTargetFramework)' == ''">net9.0-maccatalyst;</MacOSLibTargetFramework>
+        <iOSLibTargetFramework Condition="'$(iOSLibTargetFramework)' == ''">net9.0-ios;</iOSLibTargetFramework>
 
         <!-- Used for comparison to current TargetFramework -->
-        <LinuxLibTargetFramework Condition="'$(LinuxLibTargetFramework)' == ''">net8.0;net9.0;</LinuxLibTargetFramework>
-        <WasmLibTargetFramework Condition="'$(WasmLibTargetFramework)' == ''">net8.0;net9.0;</WasmLibTargetFramework>
-        <WpfLibTargetFramework Condition="'$(WpfLibTargetFramework)' == ''">net8.0;net9.0;</WpfLibTargetFramework>
+        <LinuxLibTargetFramework Condition="'$(LinuxLibTargetFramework)' == ''">net9.0;</LinuxLibTargetFramework>
+        <WasmLibTargetFramework Condition="'$(WasmLibTargetFramework)' == ''">net9.0;</WasmLibTargetFramework>
+        <WpfLibTargetFramework Condition="'$(WpfLibTargetFramework)' == ''">net9.0;</WpfLibTargetFramework>
 
         <!-- Used for defining TargetFramework under platforms that need it -->
         <DotnetStandardCommonTargetFramework Condition="'$(DotnetStandardCommonTargetFramework)' == ''">netstandard2.0</DotnetStandardCommonTargetFramework>
-        <DotnetCommonTargetFramework Condition="'$(DotnetCommonTargetFramework)' == ''">net8.0;net9.0;</DotnetCommonTargetFramework>
+        <DotnetCommonTargetFramework Condition="'$(DotnetCommonTargetFramework)' == ''">net9.0;</DotnetCommonTargetFramework>
     </PropertyGroup>
 </Project>

--- a/MultiTarget/AvailableTargetFrameworks.props
+++ b/MultiTarget/AvailableTargetFrameworks.props
@@ -1,23 +1,23 @@
 <Project>
     <PropertyGroup>
         <UwpTargetFramework Condition="'$(UwpTargetFramework)' == ''">uap10.0.17763</UwpTargetFramework>
-        <WinAppSdkTargetFramework Condition="'$(WinAppSdkTargetFramework)' == ''">net8.0-windows10.0.19041.0;net7.0-windows10.0.19041.0;net6.0-windows10.0.19041.0;</WinAppSdkTargetFramework>
+        <WinAppSdkTargetFramework Condition="'$(WinAppSdkTargetFramework)' == ''">net9.0-windows10.0.19041.0;net8.0-windows10.0.19041.0;net7.0-windows10.0.19041.0;net6.0-windows10.0.19041.0;</WinAppSdkTargetFramework>
         
-        <WasmHeadTargetFramework Condition="'$(WasmHeadTargetFramework)' == ''">net8.0</WasmHeadTargetFramework>
-        <LinuxHeadTargetFramework Condition="'$(LinuxHeadTargetFramework)' == ''">net8.0</LinuxHeadTargetFramework>
-        <WpfHeadTargetFramework Condition="'$(WpfHeadTargetFramework)' == ''">net8.0</WpfHeadTargetFramework>
+        <WasmHeadTargetFramework Condition="'$(WasmHeadTargetFramework)' == ''">net8.0;net9.0;</WasmHeadTargetFramework>
+        <LinuxHeadTargetFramework Condition="'$(LinuxHeadTargetFramework)' == ''">net8.0;net9.0;</LinuxHeadTargetFramework>
+        <WpfHeadTargetFramework Condition="'$(WpfHeadTargetFramework)' == ''">net8.0;net9.0;</WpfHeadTargetFramework>
         
-        <AndroidLibTargetFramework Condition="'$(AndroidLibTargetFramework)' == ''">net8.0-android34.0</AndroidLibTargetFramework>
-        <MacOSLibTargetFramework Condition="'$(MacOSLibTargetFramework)' == ''">net8.0-maccatalyst</MacOSLibTargetFramework>
-        <iOSLibTargetFramework Condition="'$(iOSLibTargetFramework)' == ''">net8.0-ios</iOSLibTargetFramework>
+        <AndroidLibTargetFramework Condition="'$(AndroidLibTargetFramework)' == ''">net8.0-android34.0;net9.0-android;</AndroidLibTargetFramework>
+        <MacOSLibTargetFramework Condition="'$(MacOSLibTargetFramework)' == ''">net8.0-maccatalyst;net9.0-maccatalyst;</MacOSLibTargetFramework>
+        <iOSLibTargetFramework Condition="'$(iOSLibTargetFramework)' == ''">net8.0-ios;net9.0-ios;</iOSLibTargetFramework>
 
         <!-- Used for comparison to current TargetFramework -->
-        <LinuxLibTargetFramework Condition="'$(LinuxLibTargetFramework)' == ''">net8.0</LinuxLibTargetFramework>
-        <WasmLibTargetFramework Condition="'$(WasmLibTargetFramework)' == ''">net8.0</WasmLibTargetFramework>
-        <WpfLibTargetFramework Condition="'$(WpfLibTargetFramework)' == ''">net8.0</WpfLibTargetFramework>
+        <LinuxLibTargetFramework Condition="'$(LinuxLibTargetFramework)' == ''">net8.0;net9.0;</LinuxLibTargetFramework>
+        <WasmLibTargetFramework Condition="'$(WasmLibTargetFramework)' == ''">net8.0;net9.0;</WasmLibTargetFramework>
+        <WpfLibTargetFramework Condition="'$(WpfLibTargetFramework)' == ''">net8.0;net9.0;</WpfLibTargetFramework>
 
         <!-- Used for defining TargetFramework under platforms that need it -->
         <DotnetStandardCommonTargetFramework Condition="'$(DotnetStandardCommonTargetFramework)' == ''">netstandard2.0</DotnetStandardCommonTargetFramework>
-        <DotnetCommonTargetFramework Condition="'$(DotnetCommonTargetFramework)' == ''">net8.0</DotnetCommonTargetFramework>
+        <DotnetCommonTargetFramework Condition="'$(DotnetCommonTargetFramework)' == ''">net8.0;net9.0;</DotnetCommonTargetFramework>
     </PropertyGroup>
 </Project>

--- a/MultiTarget/DefinedConstants.props
+++ b/MultiTarget/DefinedConstants.props
@@ -15,6 +15,7 @@
         <DefineConstants Condition="'$(IsWpf)' == 'true'">$(DefineConstants);HAS_UNO_SKIA;__SKIA__;WINDOWS_WPF;</DefineConstants>
         <DefineConstants Condition="'$(IsGtk)' == 'true'">$(DefineConstants);HAS_UNO_SKIA;__SKIA__;__GTK__;</DefineConstants>
 
+        <DefineConstants Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))">$(DefineConstants);NET9_0_OR_GREATER</DefineConstants>
         <DefineConstants Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">$(DefineConstants);NET8_0_OR_GREATER</DefineConstants>
         <DefineConstants Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">$(DefineConstants);NET7_0_OR_GREATER</DefineConstants>
         <DefineConstants Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">$(DefineConstants);NET6_0_OR_GREATER</DefineConstants>

--- a/MultiTarget/EnabledTargetFrameworks.props
+++ b/MultiTarget/EnabledTargetFrameworks.props
@@ -1,23 +1,23 @@
 <Project>
     <PropertyGroup>
         <UwpTargetFramework Condition="'$(UwpTargetFramework)' == ''">uap10.0.17763</UwpTargetFramework>
-        <WinAppSdkTargetFramework Condition="'$(WinAppSdkTargetFramework)' == ''">net8.0-windows10.0.19041.0;net7.0-windows10.0.19041.0;net6.0-windows10.0.19041.0;</WinAppSdkTargetFramework>
+        <WinAppSdkTargetFramework Condition="'$(WinAppSdkTargetFramework)' == ''">net9.0-windows10.0.19041.0;net8.0-windows10.0.19041.0;net7.0-windows10.0.19041.0;net6.0-windows10.0.19041.0;</WinAppSdkTargetFramework>
         
-        <WasmHeadTargetFramework Condition="'$(WasmHeadTargetFramework)' == ''">net8.0</WasmHeadTargetFramework>
-        <LinuxHeadTargetFramework Condition="'$(LinuxHeadTargetFramework)' == ''">net8.0</LinuxHeadTargetFramework>
-        <WpfHeadTargetFramework Condition="'$(WpfHeadTargetFramework)' == ''">net8.0</WpfHeadTargetFramework>
-        
-        
+        <WasmHeadTargetFramework Condition="'$(WasmHeadTargetFramework)' == ''">net8.0;net9.0;</WasmHeadTargetFramework>
+        <LinuxHeadTargetFramework Condition="'$(LinuxHeadTargetFramework)' == ''">net8.0;net9.0;</LinuxHeadTargetFramework>
+        <WpfHeadTargetFramework Condition="'$(WpfHeadTargetFramework)' == ''">net8.0;net9.0;</WpfHeadTargetFramework>
         
         
         
+        
+
         <!-- Used for comparison to current TargetFramework -->
-        <LinuxLibTargetFramework Condition="'$(LinuxLibTargetFramework)' == ''">net8.0</LinuxLibTargetFramework>
-        <WasmLibTargetFramework Condition="'$(WasmLibTargetFramework)' == ''">net8.0</WasmLibTargetFramework>
-        <WpfLibTargetFramework Condition="'$(WpfLibTargetFramework)' == ''">net8.0</WpfLibTargetFramework>
+        <LinuxLibTargetFramework Condition="'$(LinuxLibTargetFramework)' == ''">net8.0;net9.0;</LinuxLibTargetFramework>
+        <WasmLibTargetFramework Condition="'$(WasmLibTargetFramework)' == ''">net8.0;net9.0;</WasmLibTargetFramework>
+        <WpfLibTargetFramework Condition="'$(WpfLibTargetFramework)' == ''">net8.0;net9.0;</WpfLibTargetFramework>
 
         <!-- Used for defining TargetFramework under platforms that need it -->
-        <DotnetStandardCommonTargetFramework Condition="'$(DotnetStandardCommonTargetFramework)' == ''">netstandard2.0</DotnetStandardCommonTargetFramework>
-        <DotnetCommonTargetFramework Condition="'$(DotnetCommonTargetFramework)' == ''">net8.0</DotnetCommonTargetFramework>
+        
+        <DotnetCommonTargetFramework Condition="'$(DotnetCommonTargetFramework)' == ''">net8.0;net9.0;</DotnetCommonTargetFramework>
     </PropertyGroup>
 </Project>

--- a/MultiTarget/EnabledTargetFrameworks.props
+++ b/MultiTarget/EnabledTargetFrameworks.props
@@ -3,21 +3,21 @@
         <UwpTargetFramework Condition="'$(UwpTargetFramework)' == ''">uap10.0.17763</UwpTargetFramework>
         <WinAppSdkTargetFramework Condition="'$(WinAppSdkTargetFramework)' == ''">net9.0-windows10.0.19041.0;net8.0-windows10.0.19041.0;net7.0-windows10.0.19041.0;net6.0-windows10.0.19041.0;</WinAppSdkTargetFramework>
         
-        <WasmHeadTargetFramework Condition="'$(WasmHeadTargetFramework)' == ''">net8.0;net9.0;</WasmHeadTargetFramework>
-        <LinuxHeadTargetFramework Condition="'$(LinuxHeadTargetFramework)' == ''">net8.0;net9.0;</LinuxHeadTargetFramework>
-        <WpfHeadTargetFramework Condition="'$(WpfHeadTargetFramework)' == ''">net8.0;net9.0;</WpfHeadTargetFramework>
+        <WasmHeadTargetFramework Condition="'$(WasmHeadTargetFramework)' == ''">net9.0;</WasmHeadTargetFramework>
+        <LinuxHeadTargetFramework Condition="'$(LinuxHeadTargetFramework)' == ''">net9.0;</LinuxHeadTargetFramework>
+        <WpfHeadTargetFramework Condition="'$(WpfHeadTargetFramework)' == ''">net9.0;</WpfHeadTargetFramework>
         
         
         
         
 
         <!-- Used for comparison to current TargetFramework -->
-        <LinuxLibTargetFramework Condition="'$(LinuxLibTargetFramework)' == ''">net8.0;net9.0;</LinuxLibTargetFramework>
-        <WasmLibTargetFramework Condition="'$(WasmLibTargetFramework)' == ''">net8.0;net9.0;</WasmLibTargetFramework>
-        <WpfLibTargetFramework Condition="'$(WpfLibTargetFramework)' == ''">net8.0;net9.0;</WpfLibTargetFramework>
+        <LinuxLibTargetFramework Condition="'$(LinuxLibTargetFramework)' == ''">net9.0;</LinuxLibTargetFramework>
+        <WasmLibTargetFramework Condition="'$(WasmLibTargetFramework)' == ''">net9.0;</WasmLibTargetFramework>
+        <WpfLibTargetFramework Condition="'$(WpfLibTargetFramework)' == ''">net9.0;</WpfLibTargetFramework>
 
         <!-- Used for defining TargetFramework under platforms that need it -->
         
-        <DotnetCommonTargetFramework Condition="'$(DotnetCommonTargetFramework)' == ''">net8.0;net9.0;</DotnetCommonTargetFramework>
+        <DotnetCommonTargetFramework Condition="'$(DotnetCommonTargetFramework)' == ''">net9.0;</DotnetCommonTargetFramework>
     </PropertyGroup>
 </Project>

--- a/MultiTarget/MultiTargetIdentifiers.props
+++ b/MultiTarget/MultiTargetIdentifiers.props
@@ -29,25 +29,25 @@
     <MultiTargetsWasdk Condition="$(MultiTarget.Contains('wasdk')) == 'true'">true</MultiTargetsWasdk>
     <MultiTargetsNetstandard Condition="$(MultiTarget.Contains('netstandard')) == 'true'">true</MultiTargetsNetstandard>
 
-    <IsWasmHead Condition="$(IsDeployableHead) == 'true' AND '$(IsWasmHead)' == '' AND '$(TargetFramework)' == '$(WasmHeadTargetFramework)' AND '$(WasmHeadTargetFramework)' != ''">true</IsWasmHead>
-    <IsWasmLib Condition="'$(IsWasmLib)' == '' AND '$(TargetFramework)' == '$(WasmLibTargetFramework)' AND '$(MultiTargetsWasm)' == 'true' AND '$(WasmLibTargetFramework)' != ''">true</IsWasmLib>
+    <IsWasmHead Condition="$(IsDeployableHead) == 'true' AND '$(IsWasmHead)' == '' AND $(WasmHeadTargetFramework.Contains('$(TargetFramework);')) AND '$(WasmHeadTargetFramework)' != ''">true</IsWasmHead>
+    <IsWasmLib Condition="'$(IsWasmLib)' == '' AND $(WasmHeadTargetFramework.Contains('$(TargetFramework);')) AND '$(MultiTargetsWasm)' == 'true' AND '$(WasmLibTargetFramework)' != ''">true</IsWasmLib>
     <IsWasm Condition="'$(IsWasm)' == '' AND ('$(IsWasmHead)' == 'true' or '$(IsWasmLib)' == 'true')">true</IsWasm>
 
-    <IsWpfHead Condition="$(IsDeployableHead) == 'true' AND '$(IsWpfHead)' == '' AND '$(TargetFramework)' == '$(WpfHeadTargetFramework)' AND '$(WpfHeadTargetFramework)' != ''">true</IsWpfHead>
-    <IsWpfLib Condition="'$(IsWpfLib)' == '' AND '$(TargetFramework)' == '$(WpfLibTargetFramework)' AND '$(WpfLibTargetFramework)' != '' AND '$(MultiTargetsWpf)' == 'true'">true</IsWpfLib>
+    <IsWpfHead Condition="$(IsDeployableHead) == 'true' AND '$(IsWpfHead)' == '' AND $(WpfHeadTargetFramework.Contains('$(TargetFramework);')) AND '$(WpfHeadTargetFramework)' != ''">true</IsWpfHead>
+    <IsWpfLib Condition="'$(IsWpfLib)' == '' AND $(WpfLibTargetFramework.Contains('$(TargetFramework);')) AND '$(WpfLibTargetFramework)' != '' AND '$(MultiTargetsWpf)' == 'true'">true</IsWpfLib>
     <IsWpf Condition="'$(IsWpf)' == '' AND ('$(IsWpfHead)' == 'true' or '$(IsWpfLib)' == 'true')">true</IsWpf>
 
-    <IsGtkHead Condition="$(IsDeployableHead) == 'true' AND '$(IsGtkHead)' == '' AND '$(TargetFramework)' == '$(LinuxHeadTargetFramework)' AND '$(LinuxHeadTargetFramework)' != ''">true</IsGtkHead>
-    <IsGtkLib Condition="'$(IsGtkLib)' == '' AND '$(TargetFramework)' == '$(LinuxLibTargetFramework)' AND '$(LinuxLibTargetFramework)' != '' AND '$(MultiTargetsLinuxGtk)' == 'true'">true</IsGtkLib>
+    <IsGtkHead Condition="$(IsDeployableHead) == 'true' AND '$(IsGtkHead)' == '' AND $(LinuxHeadTargetFramework.Contains('$(TargetFramework);')) AND '$(LinuxHeadTargetFramework)' != ''">true</IsGtkHead>
+    <IsGtkLib Condition="'$(IsGtkLib)' == '' AND $(LinuxLibTargetFramework.Contains('$(TargetFramework);')) AND '$(LinuxLibTargetFramework)' != '' AND '$(MultiTargetsLinuxGtk)' == 'true'">true</IsGtkLib>
     <IsGtk Condition="'$(IsGtk)' == '' AND ('$(IsGtkHead)' == 'true' or '$(IsGtkLib)' == 'true')">true</IsGtk>
 
     <IsUwp Condition="'$(IsUwp)' == '' AND '$(TargetFramework)' == '$(UwpTargetFramework)' AND '$(UwpTargetFramework)' != '' AND '$(MultiTargetsUwp)' == 'true'">true</IsUwp>
     <IsWinAppSdk Condition="'$(IsWinAppSdk)' == '' AND $(WinAppSdkTargetFramework.Contains('$(TargetFramework);')) AND '$(WinAppSdkTargetFramework)' != '' AND '$(MultiTargetsWasdk)' == 'true'">true</IsWinAppSdk>
 
-    <IsDroid Condition="'$(IsDroid)' == '' AND '$(TargetFramework)' == '$(AndroidLibTargetFramework)' AND '$(AndroidLibTargetFramework)' != '' AND '$(MultiTargetsDroid)' == 'true'">true</IsDroid>
-    <IsMacOS Condition="'$(IsMacOS)' == '' AND '$(TargetFramework)' == '$(MacOSLibTargetFramework)' AND '$(MacOSLibTargetFramework)' != '' AND '$(MultiTargetsMacOS)' == 'true'">true</IsMacOS>
-    <IsiOS Condition="'$(IsiOS)' == '' AND '$(TargetFramework)' == '$(iOSLibTargetFramework)' AND '$(iOSLibTargetFramework)' != '' AND '$(MultiTargetsiOS)' == 'true'">true</IsiOS>
-    <IsNetstandard Condition="'$(IsNetstandard)' == '' AND '$(TargetFramework)' == '$(DotnetStandardCommonTargetFramework)' AND '$(MultiTargetsNetstandard)' == 'true'">true</IsNetstandard>
+    <IsDroid Condition="'$(IsDroid)' == '' AND $(AndroidLibTargetFramework.Contains('$(TargetFramework);')) AND '$(AndroidLibTargetFramework)' != '' AND '$(MultiTargetsDroid)' == 'true'">true</IsDroid>
+    <IsMacOS Condition="'$(IsMacOS)' == '' AND $(MacOSLibTargetFramework.Contains('$(TargetFramework);')) AND '$(MacOSLibTargetFramework)' != '' AND '$(MultiTargetsMacOS)' == 'true'">true</IsMacOS>
+    <IsiOS Condition="'$(IsiOS)' == '' AND $(iOSLibTargetFramework.Contains('$(TargetFramework);')) AND '$(iOSLibTargetFramework)' != '' AND '$(MultiTargetsiOS)' == 'true'">true</IsiOS>
+    <IsNetstandard Condition="'$(IsNetstandard)' == '' AND $(DotnetStandardCommonTargetFramework.Contains('$(TargetFramework);')) AND '$(MultiTargetsNetstandard)' == 'true'">true</IsNetstandard>
 
     <IsUno Condition="'$(IsWasm)' == 'true' OR '$(IsWpf)' == 'true' OR '$(IsGtk)' == 'true' OR '$(IsDroid)' == 'true' OR '$(IsMacOS)' == 'true' OR '$(IsiOS)' == 'true'">true</IsUno>
 

--- a/MultiTarget/PackageReferences/Uno.props
+++ b/MultiTarget/PackageReferences/Uno.props
@@ -7,7 +7,7 @@
     <!-- All Uno-based project heads and MultiTarget-enabled library projects need to reference this file, while native (UWP/WinAppSdk) heads don't. -->
     <ItemGroup Condition="'$(IsUno)' == 'true'">
         <PackageReference Include="Uno.UI" Version="$(CommonUnoPackageVersion)" />
-        <PackageReference Include="Uno.Fonts.Fluent" Version="2.4.5" />
+        <PackageReference Include="Uno.Fonts.Fluent" Version="2.4.5" />    
     </ItemGroup>
 
     <PropertyGroup Condition="'$(IsUno)' == 'true'">

--- a/MultiTarget/PackageReferences/Uno.props
+++ b/MultiTarget/PackageReferences/Uno.props
@@ -1,13 +1,13 @@
 <Project>
     <PropertyGroup>
-        <CommonUnoPackageVersion>5.2.132</CommonUnoPackageVersion>
+        <CommonUnoPackageVersion>5.5.66</CommonUnoPackageVersion>
     </PropertyGroup>
 
     <!-- This file is modified by UseUnoWinUI.ps1 to switch between WinUI 2 and 3 under Uno Platform -->
     <!-- All Uno-based project heads and MultiTarget-enabled library projects need to reference this file, while native (UWP/WinAppSdk) heads don't. -->
     <ItemGroup Condition="'$(IsUno)' == 'true'">
         <PackageReference Include="Uno.UI" Version="$(CommonUnoPackageVersion)" />
-        <PackageReference Include="Uno.Fonts.Fluent" Version="2.3.0" />
+        <PackageReference Include="Uno.Fonts.Fluent" Version="2.4.5" />
     </ItemGroup>
 
     <PropertyGroup Condition="'$(IsUno)' == 'true'">

--- a/MultiTarget/PackageReferences/WinAppSdk.props
+++ b/MultiTarget/PackageReferences/WinAppSdk.props
@@ -1,6 +1,6 @@
 <Project>
   <ItemGroup>
     <PackageReference Condition="'$(HasWinUI)' == 'true'" Include="Microsoft.WindowsAppSDK" Version="1.6.240923002" />
-    <PackageReference Condition="'$(HasWinUI)' == 'true'" Include="Microsoft.Web.WebView2" Version="1.0.2792.45" PrivateAssets="all" />
+    <PackageReference Condition="'$(HasWinUI)' == 'true'" Include="Microsoft.Web.WebView2" Version="1.0.2903.40" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/MultiTarget/WinUI.Extra.props
+++ b/MultiTarget/WinUI.Extra.props
@@ -23,6 +23,7 @@
   <!-- Workaround, improved error message when consuming from Uno projects with mismatched TFMs -->
   <!-- See https://github.com/CommunityToolkit/Windows/issues/388 -->
   <ItemGroup>
+    <None PackagePath="lib/net9.0-windows10.0.18362" Include="$(MSBuildThisFileDirectory)/_._" Pack="true" />
     <None PackagePath="lib/net8.0-windows10.0.18362" Include="$(MSBuildThisFileDirectory)/_._" Pack="true" />
     <None PackagePath="lib/net7.0-windows10.0.18362" Include="$(MSBuildThisFileDirectory)/_._" Pack="true" />
   </ItemGroup>

--- a/ProjectHeads/AllComponents/Wasm/CommunityToolkit.App.Wasm.csproj
+++ b/ProjectHeads/AllComponents/Wasm/CommunityToolkit.App.Wasm.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web" TreatAsLocalProperty="TargetFramework">
+<Project Sdk="Microsoft.NET.Sdk.WebAssembly" TreatAsLocalProperty="TargetFramework">
 
   <PropertyGroup>
     <IsDeployableHead>true</IsDeployableHead>

--- a/ProjectHeads/App.Head.Uno.UI.Dependencies.props
+++ b/ProjectHeads/App.Head.Uno.UI.Dependencies.props
@@ -3,7 +3,7 @@
 <Project>
   <ItemGroup>
     <!--<PackageReference Include="Uno.Microsoft.Toolkit.Uwp.UI.Controls.Markdown" Version="7.1.11" />-->
-    <PackageReference Include="Uno.Microsoft.Xaml.Behaviors.Uwp.Managed" Version="2.4.0" />
+    <PackageReference Include="Uno.Microsoft.Xaml.Behaviors.Uwp.Managed" Version="2.4.2" />
   </ItemGroup>
 </Project>
 

--- a/ProjectHeads/App.Head.Uno.UI.Dependencies.props
+++ b/ProjectHeads/App.Head.Uno.UI.Dependencies.props
@@ -3,7 +3,7 @@
 <Project>
   <ItemGroup>
     <!--<PackageReference Include="Uno.Microsoft.Toolkit.Uwp.UI.Controls.Markdown" Version="7.1.11" />-->
-    <PackageReference Include="Uno.Microsoft.Xaml.Behaviors.Uwp.Managed" Version="2.3.1-uno.2" />
+    <PackageReference Include="Uno.Microsoft.Xaml.Behaviors.Uwp.Managed" Version="2.4.0" />
   </ItemGroup>
 </Project>
 

--- a/ProjectHeads/App.Head.Uno.UI.Dependencies.props
+++ b/ProjectHeads/App.Head.Uno.UI.Dependencies.props
@@ -3,7 +3,7 @@
 <Project>
   <ItemGroup>
     <!--<PackageReference Include="Uno.Microsoft.Toolkit.Uwp.UI.Controls.Markdown" Version="7.1.11" />-->
-    <PackageReference Include="Uno.Microsoft.Xaml.Behaviors.Uwp.Managed" Version="2.4.2" />
+    <PackageReference Include="Uno.Microsoft.Xaml.Behaviors.Interactivity" Version="3.0.0-dev.17.g7c09b9114d" />
   </ItemGroup>
 </Project>
 

--- a/ProjectHeads/App.Head.Uno.WinUI.Dependencies.props
+++ b/ProjectHeads/App.Head.Uno.WinUI.Dependencies.props
@@ -3,6 +3,6 @@
 <Project>
   <ItemGroup>
     <!--<PackageReference Include="Uno.CommunityToolkit.WinUI.UI.Controls.Markdown" Version="7.1.100-dev.15.g12261e2626" />-->
-    <PackageReference Include="Uno.Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.3.1-uno.2" />
+    <PackageReference Include="Uno.Microsoft.Xaml.Behaviors.Interactivity" Version="3.0.0-dev.17.g7c09b9114d" />
   </ItemGroup>
 </Project>

--- a/ProjectHeads/App.Head.Uwp.Dependencies.props
+++ b/ProjectHeads/App.Head.Uwp.Dependencies.props
@@ -2,8 +2,8 @@
 <!-- Due to the quirks of non-sdk style projects, we cannot create a unified Dependencies.props for deployable head. -->
 <Project>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls.Markdown" Version="7.1.2" />
+    <PackageReference Include="Microsoft.Toolkit.Uwp.UI.Controls.Markdown" Version="7.1.3" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Uwp.Managed" Version="2.0.1" />
-    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="9.0.0" />
   </ItemGroup>
 </Project>

--- a/ProjectHeads/App.Head.Wasm.props
+++ b/ProjectHeads/App.Head.Wasm.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(WasmHeadTargetFramework)</TargetFramework>
+    <TargetFramework>$(WasmHeadTargetFramework.Split(';')[0])</TargetFramework>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)\App.Head.Uno.props" />

--- a/ProjectHeads/App.Head.Wasm.props
+++ b/ProjectHeads/App.Head.Wasm.props
@@ -59,13 +59,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Markdig" Version="0.31.0" />
-    <PackageReference Include="Microsoft.Windows.Compatibility" Version="8.0.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-    <PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.8.0-dev.1" />
-    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="5.2.132" />
-    <PackageReference Include="Uno.Wasm.Bootstrap" Version="8.0.14" />
-    <PackageReference Include="Uno.Wasm.Bootstrap.DevServer" Version="8.0.14" />
+    <PackageReference Include="Markdig" Version="0.38.0" />
+    <PackageReference Include="Microsoft.Windows.Compatibility" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
+    <PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.9.0-dev.2" />
+    <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="5.5.66" />
+    <PackageReference Include="Uno.Wasm.Bootstrap" Version="9.0.8" />
+    <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="9.0.0" />
+    <PackageReference Include="Uno.Wasm.Bootstrap" Version="9.0.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ProjectHeads/App.Head.WinAppSdk.Dependencies.props
+++ b/ProjectHeads/App.Head.WinAppSdk.Dependencies.props
@@ -2,7 +2,7 @@
 <!-- Due to the quirks of non-sdk style projects, we cannot create a unified Dependencies.props for deployable head. -->
 <Project>
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.Markdown" Version="7.1.3" />
+    <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.Markdown" Version="7.1.2" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.0.9" />
   </ItemGroup>
 </Project>

--- a/ProjectHeads/App.Head.WinAppSdk.Dependencies.props
+++ b/ProjectHeads/App.Head.WinAppSdk.Dependencies.props
@@ -2,7 +2,7 @@
 <!-- Due to the quirks of non-sdk style projects, we cannot create a unified Dependencies.props for deployable head. -->
 <Project>
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.Markdown" Version="7.1.2" />
+    <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.Markdown" Version="7.1.3" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.0.9" />
   </ItemGroup>
 </Project>

--- a/ProjectHeads/App.Head.props
+++ b/ProjectHeads/App.Head.props
@@ -8,13 +8,13 @@
 
   <!-- Shared project dependencies -->
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <!-- Source generators -->
   <ItemGroup Condition="'$(IsWinAppSdk)' != 'true'">
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ProjectHeads/SingleComponent/Wasm/ProjectTemplate.Wasm.csproj
+++ b/ProjectHeads/SingleComponent/Wasm/ProjectTemplate.Wasm.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web" TreatAsLocalProperty="TargetFramework">
+<Project Sdk="Microsoft.NET.Sdk.WebAssembly" TreatAsLocalProperty="TargetFramework">
 
   <PropertyGroup>
     <IsDeployableHead>true</IsDeployableHead>

--- a/ProjectHeads/Tests.Head.WinAppSdk.props
+++ b/ProjectHeads/Tests.Head.WinAppSdk.props
@@ -6,7 +6,7 @@
   <Import Project="$(MSBuildThisFileDirectory)\Head.WinAppSdk.props"/>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="17.1.0">
+    <PackageReference Include="Microsoft.TestPlatform.TestHost" Version="17.11.1">
       <ExcludeAssets>build</ExcludeAssets>
     </PackageReference>
   </ItemGroup>

--- a/ProjectHeads/Tests.Head.props
+++ b/ProjectHeads/Tests.Head.props
@@ -1,8 +1,8 @@
 <Project>
   <!-- Source generators -->
   <ItemGroup Condition="'$(IsWinAppSdk)' != 'true'">
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
   </ItemGroup>
 
   <!-- Test Dependencies -->

--- a/ToolkitComponent.SampleProject.props
+++ b/ToolkitComponent.SampleProject.props
@@ -11,7 +11,7 @@
   <!-- Import this component's source project -->
   <ItemGroup>
     <ProjectReference Include="$(MSBuildProjectDirectory)\..\src\*.csproj" />
-    <PackageReference Condition="'$(IsMacOS)' != 'true'" Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageReference Condition="'$(IsMacOS)' != 'true'" Include="System.Collections.Immutable" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.403",
+    "version": "9.0.100",
     "rollForward": "latestFeature"
   },
   "msbuild-sdks": 


### PR DESCRIPTION
This PR updates our tooling to .NET 9.0.100, including updates to:
- TargetFrameworks
  - Added alongside existing TFMs for Uno and Wasdk
  - Update tooling to handle multi-tfm value for Uno
- Dockerfile and devcontainer (used by VS Code, locally & Codespaces)
- GitHub Actions CI (build.yml)
- global.json (selects dotnet version used by runtime)
- Dependent packages (Uno Platform)