### PR TITLE
Update WASDK 1.6.241114003 and CsWinRT 2.1.6 to fix issues with StaggeredLayout in WinUI 3

### DIFF
--- a/MultiTarget/PackageReferences/WinAppSdk.props
+++ b/MultiTarget/PackageReferences/WinAppSdk.props
@@ -1,6 +1,7 @@
 <Project>
   <ItemGroup>
-    <PackageReference Condition="'$(HasWinUI)' == 'true'" Include="Microsoft.WindowsAppSDK" Version="1.6.240923002" />
+    <PackageReference Condition="'$(HasWinUI)' == 'true'" Include="Microsoft.WindowsAppSDK" Version="1.6.241114003" />
+    <PackageReference Condition="'$(HasWinUI)' == 'true'" Include="Microsoft.Windows.CsWinRt" Version="2.1.6" PrivateAssets="all" />
     <PackageReference Condition="'$(HasWinUI)' == 'true'" Include="Microsoft.Web.WebView2" Version="1.0.2792.45" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/ProjectHeads/App.Head.WinAppSdk.Dependencies.props
+++ b/ProjectHeads/App.Head.WinAppSdk.Dependencies.props
@@ -1,4 +1,4 @@
-<!-- Nuget package dependencies for all deployable UWP project heads -->
+<!-- Nuget package dependencies for all deployable WASDK project heads -->
 <!-- Due to the quirks of non-sdk style projects, we cannot create a unified Dependencies.props for deployable head. -->
 <Project>
   <ItemGroup>


### PR DESCRIPTION
We were hitting issues with ItemSource setting in WinUI 3, per similar notes in https://github.com/CommunityToolkit/Windows/issues/516 Updating CsWin32 provided better error messages (mostly to do with using `{Binding}` still in samples), but this appears to resolve the ItemsSource issue I was seeing before trying to debug https://github.com/CommunityToolkit/Windows/issues/542

With this change, at least on my x64 machine the StaggeredLayout appears to work again for WinUI 3.