### PR TITLE
Specify directory for dotnet to install to and execute from.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,8 @@ on:
 
 env:
   DOTNET_VERSION: ${{ '8.0.x' }}
+  DOTNET_INSTALL_DIR: dotnet-install
+  DOTNET_ROOT: dotnet-install
   ENABLE_DIAGNOSTICS: false
   #COREHOST_TRACE: 1
   COREHOST_TRACEFILE: corehosttrace.log

--- a/.github/workflows/config/Directory.Build.props
+++ b/.github/workflows/config/Directory.Build.props
@@ -17,8 +17,9 @@
     <Copyright>(c) .NET Foundation and Contributors.  All rights reserved.</Copyright>
     <PackageProjectUrl>https://github.com/CommunityToolkit/Tooling-Windows-Submodule</PackageProjectUrl>
     <PackageReleaseNotes>https://github.com/CommunityToolkit/Tooling-Windows-Submodule/releases</PackageReleaseNotes>
-    <!-- TODO: Remove when closing https://github.com/CommunityToolkit/Labs-Windows/issues/256 -->
-    <NoWarn>$(NoWarn);NU1505;NU1504</NoWarn>
+
+    <!-- See https://github.com/CommunityToolkit/Labs-Windows/pull/605#issuecomment-2498743676 -->
+    <WarningsNotAsErrors>NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
This PR attempts to fix the ongoing CI errors caused by GitHub Actions updating the image to include net9.0 unexpectedly. 

This setup forces only the specified dotnet version to be available when `dotnet --list-sdks` is run, avoiding the errors caused by the introduction of dotnet 9 and unblocking us while we work to resolve them in https://github.com/CommunityToolkit/Windows/pull/563.  