### PR TITLE
MultiTarget updates: Organize GlobalUsings, add HasWinUI2 msbuild property

### DIFF
--- a/.github/workflows/config/Directory.Build.props
+++ b/.github/workflows/config/Directory.Build.props
@@ -36,8 +36,4 @@
     <IsPublishable>true</IsPublishable>
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Compile Include="$(RepositoryDirectory)tooling\GlobalUsings.cs" />
-  </ItemGroup>
 </Project>

--- a/MultiTarget/Extra.props
+++ b/MultiTarget/Extra.props
@@ -1,0 +1,40 @@
+<Project>
+  <PropertyGroup Condition="'$(IsWinAppSdk)' == 'true' OR '$(IsUwp)' == 'true'">
+    <!--
+    For net5.0+ targets, TargetPlatformMinVersion was renamed to SupportedOSPlatformVersion. See https://github.com/dotnet/designs/pull/157
+
+    The dotnet SDK uses the TargetPlatformVersion property to provide a default SupportedOSPlatformVersion value if none is explicitly provided.
+    See https://github.com/dotnet/designs/blob/bba3216250cb29b0063bac3ebb57a542ee21ad4f/accepted/2020/minimum-os-version/minimum-os-version.md?plain=1#L73C27-L73C48
+    -->
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <SupportedOSPlatformVersion>$(TargetPlatformMinVersion)</SupportedOSPlatformVersion>
+    <TargetPlatformVersion Condition="'$(MultiTargetPlatformIdentifier)' == 'windows'">10.0.26100.0</TargetPlatformVersion>
+    <TargetPlatformVersion Condition="'$(MultiTargetPlatformIdentifier)' != 'windows'">10.0.19041.0</TargetPlatformVersion>
+  </PropertyGroup>
+
+  <!-- Workaround, improved error message when consuming from Uno projects with mismatched TFMs -->
+  <!-- See https://github.com/CommunityToolkit/Windows/issues/388 -->
+  <ItemGroup>
+    <None PackagePath="lib/net9.0-windows10.0.18362" Include="$(MSBuildThisFileDirectory)/_._" Pack="true" />
+    <None PackagePath="lib/net8.0-windows10.0.18362" Include="$(MSBuildThisFileDirectory)/_._" Pack="true" />
+    <None PackagePath="lib/net7.0-windows10.0.18362" Include="$(MSBuildThisFileDirectory)/_._" Pack="true" />
+  </ItemGroup>
+
+  <PropertyGroup Condition="'$(IsUwp)' == 'true'">
+    <Platforms>x86;x64;arm64</Platforms>
+    
+    <WindowsSdkPackageVersion Condition="'$(MultiTargetPlatformIdentifier)' == 'windows'">10.0.26100.54</WindowsSdkPackageVersion>
+    <RuntimeIdentifiers Condition="'$(MultiTargetPlatformIdentifier)' == 'windows'">win-x86;win-x64;win-arm64</RuntimeIdentifiers> 
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(IsWinAppSdk)' == 'true'">
+    <!-- See https://github.com/microsoft/WindowsAppSDK/issues/3842 -->
+    <UseRidGraph>true</UseRidGraph>
+    
+    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 8">win-x86;win-x64;win-arm64</RuntimeIdentifiers> 
+    <RuntimeIdentifiers Condition="8 > $([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)'))">win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
+
+    <!--- Workaround for ADO 53865998 - See https://github.com/CommunityToolkit/Tooling-Windows-Submodule/issues/215 - Don't include extraneous WebView2 dll -->
+    <WebView2NeverCopyLoaderDllToOutputDirectory>true</WebView2NeverCopyLoaderDllToOutputDirectory>
+  </PropertyGroup>
+</Project>

--- a/MultiTarget/GlobalUsings.props
+++ b/MultiTarget/GlobalUsings.props
@@ -1,0 +1,6 @@
+<Project>
+  <ItemGroup>
+    <Compile Condition="'$(EnableGlobalUsings)' != 'false' AND '$(HasWinUI)' == 'true'" Include="$(ToolingDirectory)\GlobalUsings_WinUI.cs" />
+    <Compile Condition="'$(EnableGlobalUsings)' != 'false'" Include="$(ToolingDirectory)\GlobalUsings.cs" />
+  </ItemGroup>
+</Project>

--- a/MultiTarget/Library.props
+++ b/MultiTarget/Library.props
@@ -27,6 +27,7 @@
   <!-- Configure WinUI -->
   <Import Project="$(ToolingDirectory)\MultiTarget\WinUI.AutoIncludeXamlPages.props" Condition="$(HasWinUI) == 'true'" />
   <Import Project="$(ToolingDirectory)\MultiTarget\WinUI.Extra.props" Condition="$(HasWinUI) == 'true'" />
+  <Import Project="$(ToolingDirectory)\MultiTarget\Extra.props" />
 
   <!-- Import Uno and native dependencies for all multitargeted library projects. -->
   <Import Project="$(MSBuildProjectDirectory)\Dependencies.props" Condition="Exists('$(MSBuildProjectDirectory)\Dependencies.props')" />

--- a/MultiTarget/Library.props
+++ b/MultiTarget/Library.props
@@ -17,6 +17,7 @@
   <Import Project="$(ToolingDirectory)\MultiTarget\MultiTargetIdentifiers.props" />
   <Import Project="$(ToolingDirectory)\MultiTarget\DefinedConstants.props" />
   <Import Project="$(ToolingDirectory)\MultiTarget\NoWarn.props"/>
+  <Import Project="$(ToolingDirectory)\MultiTarget\GlobalUsings.props" />
 
   <!-- Add platform package dependencies -->
   <Import Project="$(ToolingDirectory)\MultiTarget\PackageReferences\Uno.props" Condition="$(IsUno) == 'true'" />

--- a/MultiTarget/Library.props
+++ b/MultiTarget/Library.props
@@ -23,11 +23,11 @@
   <Import Project="$(ToolingDirectory)\MultiTarget\PackageReferences\Uno.props" Condition="$(IsUno) == 'true'" />
   <Import Project="$(ToolingDirectory)\MultiTarget\PackageReferences\Uwp.props" Condition="$(IsUwp) == 'true'"/>
   <Import Project="$(ToolingDirectory)\MultiTarget\PackageReferences\WinAppSdk.props" Condition="$(IsWinAppSdk) == 'true'"/>
+  <Import Project="$(ToolingDirectory)\MultiTarget\Extra.props" />
 
   <!-- Configure WinUI -->
   <Import Project="$(ToolingDirectory)\MultiTarget\WinUI.AutoIncludeXamlPages.props" Condition="$(HasWinUI) == 'true'" />
   <Import Project="$(ToolingDirectory)\MultiTarget\WinUI.Extra.props" Condition="$(HasWinUI) == 'true'" />
-  <Import Project="$(ToolingDirectory)\MultiTarget\Extra.props" />
 
   <!-- Import Uno and native dependencies for all multitargeted library projects. -->
   <Import Project="$(MSBuildProjectDirectory)\Dependencies.props" Condition="Exists('$(MSBuildProjectDirectory)\Dependencies.props')" />

--- a/MultiTarget/MultiTargetIdentifiers.props
+++ b/MultiTarget/MultiTargetIdentifiers.props
@@ -53,17 +53,17 @@
 
     <IsUno Condition="'$(IsWasm)' == 'true' OR '$(IsWpf)' == 'true' OR '$(IsGtk)' == 'true' OR '$(IsDroid)' == 'true' OR '$(IsMacOS)' == 'true' OR '$(IsiOS)' == 'true'">true</IsUno>
 
-    <HasWinUI Condition="'$(HasWinUI)' == '' AND ('$(IsUwp)' == 'true' OR '$(IsWinAppSdk)' == 'true' OR '$(IsUno)' == 'true')">true</HasWinUI>
 
     <!--
       This property is only for changing the version used by Uno.
       Force the version to 2 for UWP and 3 for WinAppSDK.
      -->
-    <WinUIMajorVersion Condition="'$(HasWinUI)' == 'true' AND '$(IsUwp)' == 'true' AND $(WinUIMajorVersion) == ''">2</WinUIMajorVersion>
-    <WinUIMajorVersion Condition="'$(HasWinUI)' == 'true' AND '$(IsWinAppSdk)' == 'true' AND $(WinUIMajorVersion) == ''">3</WinUIMajorVersion>
+    <WinUIMajorVersion Condition="'$(IsUwp)' == 'true'">2</WinUIMajorVersion>
+    <WinUIMajorVersion Condition="'$(IsWinAppSdk)' == 'true'">3</WinUIMajorVersion>
+
+    <HasWinUI Condition="'$(HasWinUI)' == '' AND '$(WinUIMajorVersion)' == '2' AND '$(HasWinUI2)' == 'false'">false</HasWinUI>
+    <HasWinUI Condition="'$(HasWinUI)' == '' AND ('$(IsUwp)' == 'true' OR '$(IsWinAppSdk)' == 'true' OR '$(IsUno)' == 'true')">true</HasWinUI>
 
     <UseUwp Condition="'$(HasWinUI)' == 'true' AND '$(IsUwp)' == 'true' AND '$(MultiTargetPlatformIdentifier)' == 'windows'">true</UseUwp>
-    
-    <HasWinUI2 Condition="'$(HasWinUI2)' == '' AND '$(HasWinUI)' == 'true' AND '$(WinUIMajorVersion)' == '2'">true</HasWinUI2>
   </PropertyGroup>
 </Project>

--- a/MultiTarget/MultiTargetIdentifiers.props
+++ b/MultiTarget/MultiTargetIdentifiers.props
@@ -63,5 +63,7 @@
     <WinUIMajorVersion Condition="'$(HasWinUI)' == 'true' AND '$(IsWinAppSdk)' == 'true' AND $(WinUIMajorVersion) == ''">3</WinUIMajorVersion>
 
     <UseUwp Condition="'$(HasWinUI)' == 'true' AND '$(IsUwp)' == 'true' AND '$(MultiTargetPlatformIdentifier)' == 'windows'">true</UseUwp>
+    
+    <HasWinUI2 Condition="'$(HasWinUI2)' == '' AND '$(HasWinUI)' == 'true' AND '$(WinUIMajorVersion)' == '2'">true</HasWinUI2>
   </PropertyGroup>
 </Project>

--- a/MultiTarget/PackageReferences/Uwp/Microsoft.UI.Xaml.props
+++ b/MultiTarget/PackageReferences/Uwp/Microsoft.UI.Xaml.props
@@ -1,12 +1,12 @@
 <Project>
 	<!-- Condition must be on a <When> statement in its own file for this to work in Visual Studio. https://stackoverflow.com/a/16557059 -->
 	<Choose>
-		<When Condition="'$(HasWinUI)' == 'true' AND '$(MultiTargetPlatformIdentifier)' != 'windows'" >
+		<When Condition="'$(HasWinUI2)' == 'true' AND '$(MultiTargetPlatformIdentifier)' != 'windows'" >
 			<ItemGroup>
 				<PackageReference Include="Microsoft.UI.Xaml" Version="2.8.6" />
 			</ItemGroup>
 		</When>
-		<When Condition="'$(HasWinUI)' == 'true' AND '$(MultiTargetPlatformIdentifier)' == 'windows'" >
+		<When Condition="'$(HasWinUI2)' == 'true' AND '$(MultiTargetPlatformIdentifier)' == 'windows'" >
 			<ItemGroup>
 				<!-- Prerelease version needed for TargetFramework support. Not needed by uap. -->
 				<PackageReference Include="Microsoft.UI.Xaml" Version="2.8.7-prerelease.241119001" />

--- a/MultiTarget/PackageReferences/Uwp/Microsoft.UI.Xaml.props
+++ b/MultiTarget/PackageReferences/Uwp/Microsoft.UI.Xaml.props
@@ -1,12 +1,12 @@
 <Project>
 	<!-- Condition must be on a <When> statement in its own file for this to work in Visual Studio. https://stackoverflow.com/a/16557059 -->
 	<Choose>
-		<When Condition="'$(HasWinUI2)' == 'true' AND '$(MultiTargetPlatformIdentifier)' != 'windows'" >
+		<When Condition="'$(HasWinUI)' == 'true' AND '$(MultiTargetPlatformIdentifier)' != 'windows'" >
 			<ItemGroup>
 				<PackageReference Include="Microsoft.UI.Xaml" Version="2.8.6" />
 			</ItemGroup>
 		</When>
-		<When Condition="'$(HasWinUI2)' == 'true' AND '$(MultiTargetPlatformIdentifier)' == 'windows'" >
+		<When Condition="'$(HasWinUI)' == 'true' AND '$(MultiTargetPlatformIdentifier)' == 'windows'" >
 			<ItemGroup>
 				<!-- Prerelease version needed for TargetFramework support. Not needed by uap. -->
 				<PackageReference Include="Microsoft.UI.Xaml" Version="2.8.7-prerelease.241119001" />

--- a/MultiTarget/WinUI.Extra.props
+++ b/MultiTarget/WinUI.Extra.props
@@ -8,45 +8,6 @@
     <EnableDefaultPageItems>false</EnableDefaultPageItems>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(IsWinAppSdk)' == 'true' OR '$(IsUwp)' == 'true'">
-    <!--
-    For net5.0+ targets, TargetPlatformMinVersion was renamed to SupportedOSPlatformVersion. See https://github.com/dotnet/designs/pull/157
-
-    The dotnet SDK uses the TargetPlatformVersion property to provide a default SupportedOSPlatformVersion value if none is explicitly provided.
-    See https://github.com/dotnet/designs/blob/bba3216250cb29b0063bac3ebb57a542ee21ad4f/accepted/2020/minimum-os-version/minimum-os-version.md?plain=1#L73C27-L73C48
-    -->
-    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
-    <SupportedOSPlatformVersion>$(TargetPlatformMinVersion)</SupportedOSPlatformVersion>
-    <TargetPlatformVersion Condition="'$(MultiTargetPlatformIdentifier)' == 'windows'">10.0.26100.0</TargetPlatformVersion>
-    <TargetPlatformVersion Condition="'$(MultiTargetPlatformIdentifier)' != 'windows'">10.0.19041.0</TargetPlatformVersion>
-  </PropertyGroup>
-
-  <!-- Workaround, improved error message when consuming from Uno projects with mismatched TFMs -->
-  <!-- See https://github.com/CommunityToolkit/Windows/issues/388 -->
-  <ItemGroup>
-    <None PackagePath="lib/net9.0-windows10.0.18362" Include="$(MSBuildThisFileDirectory)/_._" Pack="true" />
-    <None PackagePath="lib/net8.0-windows10.0.18362" Include="$(MSBuildThisFileDirectory)/_._" Pack="true" />
-    <None PackagePath="lib/net7.0-windows10.0.18362" Include="$(MSBuildThisFileDirectory)/_._" Pack="true" />
-  </ItemGroup>
-
-  <PropertyGroup Condition="'$(IsUwp)' == 'true'">
-    <Platforms>x86;x64;arm64</Platforms>
-    
-    <WindowsSdkPackageVersion Condition="'$(MultiTargetPlatformIdentifier)' == 'windows'">10.0.26100.54</WindowsSdkPackageVersion>
-    <RuntimeIdentifiers Condition="'$(MultiTargetPlatformIdentifier)' == 'windows'">win-x86;win-x64;win-arm64</RuntimeIdentifiers> 
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(IsWinAppSdk)' == 'true'">
-    <!-- See https://github.com/microsoft/WindowsAppSDK/issues/3842 -->
-    <UseRidGraph>true</UseRidGraph>
-    
-    <RuntimeIdentifiers Condition="$([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)')) >= 8">win-x86;win-x64;win-arm64</RuntimeIdentifiers> 
-    <RuntimeIdentifiers Condition="8 > $([MSBuild]::GetTargetFrameworkVersion('$(TargetFramework)'))">win10-x86;win10-x64;win10-arm64</RuntimeIdentifiers>
-
-    <!--- Workaround for ADO 53865998 - See https://github.com/CommunityToolkit/Tooling-Windows-Submodule/issues/215 - Don't include extraneous WebView2 dll -->
-    <WebView2NeverCopyLoaderDllToOutputDirectory>true</WebView2NeverCopyLoaderDllToOutputDirectory>
-  </PropertyGroup>
-
   <PropertyGroup Condition="'$(IsUno)' == 'true'">
     <!-- Xaml Trimming: https://platform.uno/docs/articles/features/resources-trimming.html -->
     <UnoXamlResourcesTrimming>true</UnoXamlResourcesTrimming>
@@ -56,19 +17,4 @@
     <!-- These suppressions are for references between generated assemblies and that VS can keep in the Error List once resolved -->
     <NoWarn>$(NoWarn);WMC1006;CS8034;</NoWarn>
   </PropertyGroup>
-  
-  <!-- Disable warnings for 'This call site is reachable on all platforms.' caused by underlying platform. -->
-  <PropertyGroup Condition="'$(IsUwp)' == 'true' AND '$(MultiTargetPlatformIdentifier)' == 'windows'">
-    <NoWarn>$(NoWarn);CA1416;</NoWarn>
-  </PropertyGroup>
-
-  <!-- Workaround for Mac: https://developercommunity.visualstudio.com/t/XamarinMac-binaries-are-missing-in-173/10164443#T-N10164676 10/6/22 -->
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('xamarinmac')) ">
-    <Reference Include="Xamarin.Mac">
-      <HintPath Condition="Exists('c:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\Extensions\Xamarin.VisualStudio')">c:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\IDE\Extensions\Xamarin.VisualStudio\Xamarin.Mac.dll</HintPath>
-      <HintPath Condition="Exists('c:\Program Files\Microsoft Visual Studio\2022\Professional\Common7\IDE\Extensions\Xamarin.VisualStudio')">c:\Program Files\Microsoft Visual Studio\2022\Professional\Common7\IDE\Extensions\Xamarin.VisualStudio\Xamarin.Mac.dll</HintPath>
-      <HintPath Condition="Exists('c:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\Extensions\Xamarin.VisualStudio')">c:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\Extensions\Xamarin.VisualStudio\Xamarin.Mac.dll</HintPath>
-      <HintPath Condition="Exists('c:\Program Files\Microsoft Visual Studio\2022\Preview\Common7\IDE\Extensions\Xamarin.VisualStudio')">c:\Program Files\Microsoft Visual Studio\2022\Preview\Common7\IDE\Extensions\Xamarin.VisualStudio\Xamarin.Mac.dll</HintPath>
-    </Reference>
-  </ItemGroup>
 </Project>

--- a/MultiTarget/WinUI.Extra.props
+++ b/MultiTarget/WinUI.Extra.props
@@ -62,10 +62,6 @@
     <NoWarn>$(NoWarn);CA1416;</NoWarn>
   </PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include="$(ToolingDirectory)\GlobalUsings_WinUI.cs" />
-  </ItemGroup>
-
   <!-- Workaround for Mac: https://developercommunity.visualstudio.com/t/XamarinMac-binaries-are-missing-in-173/10164443#T-N10164676 10/6/22 -->
   <ItemGroup Condition=" $(TargetFramework.StartsWith('xamarinmac')) ">
     <Reference Include="Xamarin.Mac">

--- a/ProjectHeads/App.Head.props
+++ b/ProjectHeads/App.Head.props
@@ -1,5 +1,8 @@
 <!-- Common props for any deployable app project head. -->
 <Project>
+  <Import Project="$(MSBuildThisFileDirectory)\..\MultiTarget\Extra.props" />
+  <Import Project="$(ToolingDirectory)\MultiTarget\GlobalUsings.props" />
+
   <!-- Shared project -->
   <Import Project="$(ToolingDirectory)\CommunityToolkit.App.Shared\CommunityToolkit.App.Shared.projitems" Label="Shared" />
 

--- a/ProjectHeads/GenerateSingleSampleHeads.ps1
+++ b/ProjectHeads/GenerateSingleSampleHeads.ps1
@@ -89,7 +89,6 @@ if ($MultiTargets.Contains('uwp') -and $MultiTargets.Contains('wasdk'))
 }
 
 $MultiTargets = $MultiTargets | Where-Object { $_ -notin $ExcludeMultiTargets }
-$ExcludeMultiTargets = $ExcludeMultiTargets | Where-Object { $_ -notin $MultiTargets }
 
 # Generate required props for preferences
 & $PSScriptRoot/../MultiTarget/UseTargetFrameworks.ps1 -MultiTargets $MultiTargets

--- a/ProjectHeads/Tests.Head.props
+++ b/ProjectHeads/Tests.Head.props
@@ -1,4 +1,7 @@
 <Project>
+  <Import Project="$(MSBuildThisFileDirectory)\..\MultiTarget\Extra.props" />
+  <Import Project="$(ToolingDirectory)\MultiTarget\GlobalUsings.props" />
+
   <!-- Source generators -->
   <ItemGroup Condition="'$(IsWinAppSdk)' != 'true'">
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" PrivateAssets="all" />


### PR DESCRIPTION
This PR:
- Organizes our GlobalUsings
  - Cleans up random imports or exclusions
  - Adds a `EnableGlobalUsings` property (enabled by default)
    - Respects the `HasWinUI` property when importing `GlobalUsings.WinUI.cs`.
    - Removes imports in various files that no longer need it
- Adds a `HasWinUI2` property to complement our existing `HasWinUI` property.
  - Can be used to enable or disable references to `Microsoft.UI.Xaml` when running under UWP _without_ turning off references to WinUI (wasdk, uno) on other deployable targets.