### PR TITLE
Add 'net9.0-windows10.0.26100.0' TFM to UWP

### DIFF
--- a/MultiTarget/AvailableTargetFrameworks.props
+++ b/MultiTarget/AvailableTargetFrameworks.props
@@ -7,7 +7,9 @@
     <PropertyGroup>
         <!-- See https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/235#issuecomment-2530131559 -->
         <UwpTargetFrameworks Condition="'$(UwpTargetFrameworks)' == '' AND '$(BuildingInsideVisualStudio)' == 'true'">uap10.0.17763;</UwpTargetFrameworks>
-        <UwpTargetFrameworks Condition="'$(UwpTargetFrameworks)' == '' AND '$(BuildingInsideVisualStudio)' != 'true'">uap10.0.17763;net8.0-windows10.0.26100.0;</UwpTargetFrameworks>
+
+        <!-- We also include 'net9.0-windows10.0.26100.0' explicitly for UWP as a workaround for https://github.com/CommunityToolkit/Tooling-Windows-Submodule/issues/238 -->
+        <UwpTargetFrameworks Condition="'$(UwpTargetFrameworks)' == '' AND '$(BuildingInsideVisualStudio)' != 'true'">uap10.0.17763;net8.0-windows10.0.26100.0;net9.0-windows10.0.26100.0;</UwpTargetFrameworks>
         <WinAppSdkTargetFrameworks Condition="'$(WinAppSdkTargetFrameworks)' == ''">net9.0-windows10.0.19041.0;net8.0-windows10.0.19041.0;</WinAppSdkTargetFrameworks>
         
         <WasmHeadTargetFramework Condition="'$(WasmHeadTargetFramework)' == ''">net9.0;</WasmHeadTargetFramework>


### PR DESCRIPTION
### Workaround for #238

This PR adds the `net9.0-windows10.0.26100.0` TFM for UWP.