### PR TITLE
Fixed ExcludeMultiTargets not working as expected

### DIFF
--- a/MultiTarget/UseTargetFrameworks.ps1
+++ b/MultiTarget/UseTargetFrameworks.ps1
@@ -39,13 +39,14 @@ $AllMultiTargets = @('wasm', 'uwp', 'wasdk', 'wpf', 'linuxgtk', 'macos', 'ios', 
 # Exclude as needed
 foreach ($excluded in $ExcludeMultiTargets) {
     $MultiTargets = $MultiTargets.Where({ $_ -ne $excluded });
+    $AllMultiTargets = $AllMultiTargets.Where({ $_ -ne $excluded });
 }
 
 Write-Output "Setting enabled MultiTargets: $MultiTargets"
 
 # 'all' represents all available '$MultiTargets' values
 if ($MultiTargets.Contains("all")) {
-    $enabledMultiTargets = @('$(AvailableMultiTargets)')
+    $enabledMultiTargets = $AllMultiTargets -join ";"
 }
 else {
     $enabledMultiTargets = $AllMultiTargets.Where({ $MultiTargets.Contains($_) }) -join ";"


### PR DESCRIPTION
This PR fixes an issue where the `ExcludeMultiTargets` parameter passed to `UseTargetFrameworks.ps1` wasn't being reflected in the generated code. 

This led to issues in our CI, which relies on this parameter to ensure that UWP does not build for WinUI 3, and vice versa. 

Note the `net9.0-windows10.0.19041` TFM, which is only used for the wasdk MultiTarget. This is the Uwp package, so this should not be here:
![image](https://github.com/user-attachments/assets/03df4829-8877-4375-b3bd-6ff8fb27b6a7)
