### PR TITLE
Update CommunityToolkit package references to version 8.2.241223-build.1367

### DIFF
--- a/ProjectHeads/App.Head.props
+++ b/ProjectHeads/App.Head.props
@@ -32,7 +32,7 @@
   <Choose>
     <When Condition="'$(ToolkitConvertersSourceProject)' == ''">
       <ItemGroup>
-        <PackageReference Include="CommunityToolkit.$(DependencyVariant).Converters" Version="8.0.230907"/>
+        <PackageReference Include="CommunityToolkit.$(DependencyVariant).Converters" Version="8.2.241223-build.1367"/>
       </ItemGroup>
     </When>
     <!-- This is tripping up the linux build using dotnet build as we have a duplicate reference 
@@ -49,7 +49,7 @@
   <Choose>
     <When Condition="'$(ToolkitSettingsControlsSourceProject)' == ''">
       <ItemGroup>
-        <PackageReference Include="CommunityToolkit.$(DependencyVariant).Controls.SettingsControls" Version="8.0.230907"/>
+        <PackageReference Include="CommunityToolkit.$(DependencyVariant).Controls.SettingsControls" Version="8.2.241223-build.1367"/>
       </ItemGroup>
     </When>
     <When Condition="'$(IsSingleExperimentHead)' == 'true' and $(MSBuildProjectName.StartsWith('SettingsControls')) == 'false'">
@@ -61,7 +61,7 @@
   <Choose>
     <When Condition="'$(ToolkitExtensionsSourceProject)' == ''">
       <ItemGroup>
-        <PackageReference Include="CommunityToolkit.$(DependencyVariant).Extensions" Version="8.0.230907"/>
+        <PackageReference Include="CommunityToolkit.$(DependencyVariant).Extensions" Version="8.2.241223-build.1367"/>
       </ItemGroup>
     </When>
     <When Condition="'$(IsSingleExperimentHead)' == 'true' and $(MSBuildProjectName.StartsWith('Extensions')) == 'false'">
@@ -73,7 +73,7 @@
   <Choose>
     <When Condition="'$(ToolkitTriggersSourceProject)' == ''">
       <ItemGroup>
-        <PackageReference Include="CommunityToolkit.$(DependencyVariant).Triggers" Version="8.0.230907"/>
+        <PackageReference Include="CommunityToolkit.$(DependencyVariant).Triggers" Version="8.2.241223-build.1367"/>
       </ItemGroup>
     </When>
     <When Condition="'$(IsSingleExperimentHead)' == 'true' and $(MSBuildProjectName.StartsWith('Triggers')) == 'false'">

--- a/ProjectHeads/Tests.Head.props
+++ b/ProjectHeads/Tests.Head.props
@@ -19,7 +19,7 @@
   <Choose>
     <When Condition="'$(ToolkitExtensionsSourceProject)' == ''">
       <ItemGroup>
-        <PackageReference Include="CommunityToolkit.$(DependencyVariant).Extensions" Version="8.0.230907"/>
+        <PackageReference Include="CommunityToolkit.$(DependencyVariant).Extensions" Version="8.2.241223-build.1367"/>
       </ItemGroup>
     </When>
     <When Condition="'$(IsSingleExperimentHead)' == 'true' and $(MSBuildProjectName.StartsWith('Extensions')) == 'false'">


### PR DESCRIPTION
This PR updates the packages used by the gallery when the components aren't present in the solution to version 8.2.241223-build.1367 from the `MainLatest` feed. 

This fixes package downgrade errors when building gallery in the PR https://github.com/CommunityToolkit/Labs-Windows/pull/618