### PR TITLE
Improve semicolon delimiter consistency, fix `IsNetstandard` property

### DIFF
--- a/MultiTarget/AvailableTargetFrameworks.props
+++ b/MultiTarget/AvailableTargetFrameworks.props
@@ -26,7 +26,7 @@
         <WpfLibTargetFrameworks Condition="'$(WpfLibTargetFrameworks)' == ''">net9.0;</WpfLibTargetFrameworks>
 
         <!-- Used for defining TargetFramework under platforms that need it -->
-        <DotnetStandardCommonTargetFramework Condition="'$(DotnetStandardCommonTargetFramework)' == ''">netstandard2.0</DotnetStandardCommonTargetFramework>
+        <DotnetStandardCommonTargetFramework Condition="'$(DotnetStandardCommonTargetFramework)' == ''">netstandard2.0;</DotnetStandardCommonTargetFramework>
         <DotnetCommonTargetFramework Condition="'$(DotnetCommonTargetFramework)' == ''">net9.0;</DotnetCommonTargetFramework>
     </PropertyGroup>
 </Project>

--- a/MultiTarget/EnabledMultiTargets.props
+++ b/MultiTarget/EnabledMultiTargets.props
@@ -2,6 +2,6 @@
     <!--Indicates which MultiTargets are enabled via UseTargetFrameworks script. -->
     <!-- Do not commit changes made to default values by tooling. -->
   <PropertyGroup>
-    <EnabledMultiTargets>wasm;uwp;netstandard</EnabledMultiTargets>
+    <EnabledMultiTargets>wasm;uwp;netstandard;</EnabledMultiTargets>
   </PropertyGroup>
 </Project>

--- a/MultiTarget/UseTargetFrameworks.ps1
+++ b/MultiTarget/UseTargetFrameworks.ps1
@@ -55,7 +55,7 @@ else {
 # When enabledMultiTargetsRegexPartial is empty, the regex will match everything.
 # To work around this, check if there's anything to remove before doing it.
 if ($enabledMultiTargets.Length -gt 0) {
-    $newFileContents = $fileContents -replace "\<EnabledMultiTargets\>(.+?)\<\/EnabledMultiTargets\>", "<EnabledMultiTargets>$enabledMultiTargets</EnabledMultiTargets>";
+    $newFileContents = $fileContents -replace "\<EnabledMultiTargets\>(.+?)\<\/EnabledMultiTargets\>", "<EnabledMultiTargets>$enabledMultiTargets;</EnabledMultiTargets>";
 }
 
 Set-Content -Force -Path $PSScriptRoot/EnabledMultiTargets.props -Value $newFileContents;


### PR DESCRIPTION
This pull request includes minor changes to the target framework properties and the `UseTargetFrameworks` script to ensure consistency by adding semicolons at the end of framework lists.

Changes to target framework properties:

* [`MultiTarget/AvailableTargetFrameworks.props`](diffhunk://#diff-3e274bd0c8181e6228278f26cc15080d741ef6551834c9eae565a829019975d3L29-R29): Added a semicolon at the end of the `DotnetStandardCommonTargetFramework` property value.
* [`MultiTarget/EnabledMultiTargets.props`](diffhunk://#diff-fd1a599e607d6912f632a2d1e5189e0ee82b59e95c23a809441fc256e3e06c2aL5-R5): Added a semicolon at the end of the `EnabledMultiTargets` property value.

Changes to `UseTargetFrameworks` script:

* [`MultiTarget/UseTargetFrameworks.ps1`](diffhunk://#diff-e690938467c6661c771e592e945bac7fdadff2aadc14f7a9d607c7b8f43ef95aL58-R58): Modified the regex replacement to include a semicolon at the end of the `EnabledMultiTargets` property value.

The delimiter is needed to avoid problems with the `Contains` checks between TFMs such as `net9.0` and `net9.0-windows*`.