### PR TITLE
Update target framework to .NET 8 for SampleGen and TestGen

### DIFF
--- a/CommunityToolkit.Tooling.SampleGen.Tests/CommunityToolkit.Tooling.SampleGen.Tests.csproj
+++ b/CommunityToolkit.Tooling.SampleGen.Tests/CommunityToolkit.Tooling.SampleGen.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>

--- a/CommunityToolkit.Tooling.TestGen.Tests/CommunityToolkit.Tooling.TestGen.Tests.csproj
+++ b/CommunityToolkit.Tooling.TestGen.Tests/CommunityToolkit.Tooling.TestGen.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
This PR upgrades our SampleGen and TestGen projects to net8.0. 

This fixes a build error (see [here](https://github.com/CommunityToolkit/Tooling-Windows-Submodule/actions/runs/12694712500/job/35385085749?pr=245)) caused by the removal of net6.0 in the CI images. 