### PR TITLE
Update uno.check tool version to 1.27.4

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "uno.check": {
-      "version": "1.27.1",
+      "version": "1.27.4",
       "commands": [
         "uno-check"
       ]

--- a/ProjectHeads/App.Head.Wasm.props
+++ b/ProjectHeads/App.Head.Wasm.props
@@ -69,7 +69,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
     <PackageReference Include="Uno.Extensions.Logging.WebAssembly.Console" Version="1.9.0-dev.2" />
     <PackageReference Include="Uno.UI.Adapter.Microsoft.Extensions.Logging" Version="5.5.66" />
-    <PackageReference Include="Uno.Wasm.Bootstrap" Version="9.0.8" />
+    <PackageReference Include="Uno.Wasm.Bootstrap" Version="9.0.10" />
     <PackageReference Include="Microsoft.NET.ILLink.Tasks" Version="9.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
This PR updates our uno.check version to the latest 1.27.4