### PR TITLE
Fix wasdk Sample Gallery not building

### DIFF
--- a/MultiTarget/Extra.props
+++ b/MultiTarget/Extra.props
@@ -10,6 +10,8 @@
     <SupportedOSPlatformVersion>$(TargetPlatformMinVersion)</SupportedOSPlatformVersion>
     <TargetPlatformVersion Condition="'$(MultiTargetPlatformIdentifier)' == 'windows'">10.0.26100.0</TargetPlatformVersion>
     <TargetPlatformVersion Condition="'$(MultiTargetPlatformIdentifier)' != 'windows'">10.0.19041.0</TargetPlatformVersion>
+    
+    <Platforms>x86;x64;arm64</Platforms>
   </PropertyGroup>
 
   <!-- Workaround, improved error message when consuming from Uno projects with mismatched TFMs -->
@@ -20,9 +22,7 @@
     <None PackagePath="lib/net7.0-windows10.0.18362" Include="$(MSBuildThisFileDirectory)/_._" Pack="true" />
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(IsUwp)' == 'true'">
-    <Platforms>x86;x64;arm64</Platforms>
-    
+  <PropertyGroup Condition="'$(IsUwp)' == 'true'">    
     <WindowsSdkPackageVersion Condition="'$(MultiTargetPlatformIdentifier)' == 'windows'">10.0.26100.57</WindowsSdkPackageVersion>
     <RuntimeIdentifiers Condition="'$(MultiTargetPlatformIdentifier)' == 'windows'">win-x86;win-x64;win-arm64</RuntimeIdentifiers> 
   </PropertyGroup>


### PR DESCRIPTION
This PR fixes an issue where the Sample Gallery solution in generated in WinUI 3 mode couldn't build the libraries or gallery heads, citing "Current solution contains incorrect configurations mappings."

![image](https://github.com/user-attachments/assets/e01a19cb-c14c-42af-837b-8883eef73c88)

Issue was fixed by defining the `Platforms` property for libraries on both UWP and WinUI 3, instead of just UWP. It was presumed (given advice from @Sergio0694 iirc) that the SDK would define this property for us, but the behavior here suggests otherwise and has been corrected.