### PR TITLE
Initial take on fixing sample app source/package links for Labs experimental components

### DIFF
--- a/CommunityToolkit.App.Shared/Renderers/ToolkitDocumentationRenderer.xaml
+++ b/CommunityToolkit.App.Shared/Renderers/ToolkitDocumentationRenderer.xaml
@@ -1,4 +1,4 @@
-﻿<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
+<!--  Licensed to the .NET Foundation under one or more agreements. The .NET Foundation licenses this file to you under the MIT license. See the LICENSE file in the project root for more information.  -->
 <Page x:Class="CommunityToolkit.App.Shared.Renderers.ToolkitDocumentationRenderer"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -230,7 +230,7 @@
                     </StackPanel>
                     <interactivity:Interaction.Behaviors>
                         <interactivity:EventTriggerBehavior EventName="Click">
-                            <behaviors:NavigateToUriAction NavigateUri="{x:Bind renderer:ToolkitDocumentationRenderer.ToComponentUri(Metadata.ComponentName), Mode=OneWay}" />
+                            <behaviors:NavigateToUriAction NavigateUri="{x:Bind renderer:ToolkitDocumentationRenderer.ToComponentUri(Metadata.ComponentName, Metadata.IsExperimental), Mode=OneWay}" />
                         </interactivity:EventTriggerBehavior>
                     </interactivity:Interaction.Behaviors>
                 </Button>
@@ -258,16 +258,16 @@
                                            Text="NuGet package" />
                                 <TextBlock IsTextSelectionEnabled="True">
                                     <Hyperlink FontFamily="Consolas"
-                                               NavigateUri="{x:Bind renderer:ToolkitDocumentationRenderer.ToPackageUri('Uwp', Metadata.CsProjName), Mode=OneWay}"
+                                               NavigateUri="{x:Bind renderer:ToolkitDocumentationRenderer.ToPackageUri('Uwp', Metadata.CsProjName, Metadata.IsExperimental), Mode=OneWay}"
                                                TextDecorations="None">
-                                        <Run Text="{x:Bind renderer:ToolkitDocumentationRenderer.ToPackageName('Uwp', Metadata.CsProjName), Mode=OneWay}" />
+                                        <Run Text="{x:Bind renderer:ToolkitDocumentationRenderer.ToPackageName('Uwp', Metadata.CsProjName, Metadata.IsExperimental), Mode=OneWay}" />
                                     </Hyperlink>
                                 </TextBlock>
                                 <TextBlock IsTextSelectionEnabled="True">
                                     <Hyperlink FontFamily="Consolas"
-                                               NavigateUri="{x:Bind renderer:ToolkitDocumentationRenderer.ToPackageUri('WinUI', Metadata.CsProjName), Mode=OneWay}"
+                                               NavigateUri="{x:Bind renderer:ToolkitDocumentationRenderer.ToPackageUri('WinUI', Metadata.CsProjName, Metadata.IsExperimental), Mode=OneWay}"
                                                TextDecorations="None">
-                                        <Run Text="{x:Bind renderer:ToolkitDocumentationRenderer.ToPackageName('WinUI', Metadata.CsProjName), Mode=OneWay}" />
+                                        <Run Text="{x:Bind renderer:ToolkitDocumentationRenderer.ToPackageName('WinUI', Metadata.CsProjName, Metadata.IsExperimental), Mode=OneWay}" />
                                     </Hyperlink>
                                 </TextBlock>
                             </StackPanel>

--- a/CommunityToolkit.App.Shared/Renderers/ToolkitDocumentationRenderer.xaml.cs
+++ b/CommunityToolkit.App.Shared/Renderers/ToolkitDocumentationRenderer.xaml.cs
@@ -216,11 +216,35 @@ public sealed partial class ToolkitDocumentationRenderer : Page
 
     public static Uri? ToGitHubUri(string path, int id) => IsProjectPathValid() ? new Uri($"{ProjectUrl}/{path}/{id}") : null;
 
-    public static Uri? ToComponentUri(string name) => IsProjectPathValid() ? new Uri($"{ProjectUrl}/tree/main/components/{name}") : null;
+    public static Uri? ToComponentUri(string name, bool? isExperimental = null)
+    {
+        if (IsProjectPathValid() is not true)
+        {
+            return null;
+        }
 
-    public static Uri? ToPackageUri(string platform, string projectFileName) => new Uri($"https://www.nuget.org/packages/{RemoveFileExtension(projectFileName).Replace("WinUI", platform)}");
+        string? url = (isExperimental is null || isExperimental is false)
+            ? ProjectUrl
+            : ProjectUrl?.Replace("Windows", "Labs-Windows");
 
-    public static string ToPackageName(string platform, string projectFileName) => RemoveFileExtension(projectFileName).Replace("WinUI", platform);
+        return new Uri($"{url}/tree/main/components/{name}");
+    }
+
+    public static Uri? ToPackageUri(string platform, string projectFileName, bool? isExperimental = null)
+    {
+        if (isExperimental is null || isExperimental is false)
+        {
+            return new Uri($"https://www.nuget.org/packages/{ToPackageName(platform, projectFileName, isExperimental)}");
+        }
+        else
+        {
+            // Labs feed for experimental packages (currently)
+            // See inconsistency for Labs package names/project names https://github.com/CommunityToolkit/Windows/issues/587#issuecomment-2738529086
+            return new Uri($"https://dev.azure.com/dotnet/CommunityToolkit/_artifacts/feed/CommunityToolkit-Labs/NuGet/{ToPackageName(platform, projectFileName, isExperimental)}");
+        }
+    }
+    
+    public static string ToPackageName(string platform, string projectFileName, bool? isExperimental) => RemoveFileExtension(projectFileName).Replace("CommunityToolkit.WinUI", isExperimental == true ? "CommunityToolkit.Labs.WinUI" : "CommunityToolkit.WinUI").Replace("WinUI", platform);
 
     // TODO: Think this is most of the special cases with Controls and the Extensions/Triggers using the base namespace
     // See: https://github.com/CommunityToolkit/Tooling-Windows-Submodule/issues/105#issuecomment-1698306420


### PR DESCRIPTION
See https://github.com/CommunityToolkit/Windows/issues/587 

At least in part, there's many inconsistencies in the Labs packages from changes to templates. Both in inclusion of `.Labs.` in package as well as `.Controls.` or not.

Something we should fix in the Labs repo so everything is consistent with how the packages are named (between source, csproj props, and nuget packages).

That will make some of this code obsolete, but should just work, so we can commit here and fix in Labs after so the sample app can be correctly pointing to all packages.

(Note it's hard to copy labs components into the main repo, and vice-versa due to dependencies. We need a method in labs where we reference toolkit components differently so we can just assign properties for project reference vs. package reference, etc... [There may be an issue for that already?])