### PR TITLE
Topmode for NavigationView

### DIFF
--- a/CommunityToolkit.App.Shared/Helpers/NavigationViewHelper.cs
+++ b/CommunityToolkit.App.Shared/Helpers/NavigationViewHelper.cs
@@ -14,25 +14,18 @@ public static class NavigationViewHelper
 
         foreach (var navData in categoryData)
         {
-            // Make subcategories
-            var subcategoryData = GenerateSubcategoryNavItems(navData.SampleMetadata ?? Enumerable.Empty<ToolkitFrontMatter>());
+            var samplesBySubcategory = navData.SampleMetadata!.GroupBy(x => x.Subcategory)
+                                             .OrderBy(g => g.Key.ToString());
 
-            foreach (var subcategoryItemData in subcategoryData)
+            foreach (var subcategoryGroup in samplesBySubcategory)
             {
-                // Make samples
-                var sampleNavigationItems = GenerateSampleNavItems(subcategoryItemData.SampleMetadata ?? Enumerable.Empty<ToolkitFrontMatter>());
-                subcategoryItemData.NavItem.MenuItems.Add(new MUXC.NavigationViewItemSeparator());
-                foreach (var item in sampleNavigationItems)
+                navData.NavItem.MenuItems.Add(new MUXC.NavigationViewItemHeader() { Content = subcategoryGroup.Key.ToString() });
+                foreach (var sampleNavItem in GenerateSampleNavItems(subcategoryGroup))
                 {
-                    // Add sample to subcategory
-                    subcategoryItemData.NavItem.MenuItems.Add(item);
+                    navData.NavItem.MenuItems.Add(sampleNavItem);
                 }
-
-                // Add subcategory to category
-                navData.NavItem.MenuItems.Add(subcategoryItemData.NavItem);
             }
 
-            // Return category
             yield return navData.NavItem;
         }
     }
@@ -61,23 +54,6 @@ public static class NavigationViewHelper
         }
     }
 
-    private static IEnumerable<GroupNavigationItemData> GenerateSubcategoryNavItems(IEnumerable<ToolkitFrontMatter> sampleMetadata)
-    {
-        var samplesBySubcategory = sampleMetadata.GroupBy(x => x.Subcategory)
-                                                 .OrderBy(g => g.Key.ToString());
-
-        foreach (var subcategoryGroup in samplesBySubcategory)
-        {
-            yield return new GroupNavigationItemData(new MUXC.NavigationViewItem
-            {
-                Content = subcategoryGroup.Key,
-                SelectsOnInvoked = false,
-                IsExpanded = false,
-                Style = (Style)App.Current.Resources["SubcategoryNavigationViewItemStyle"],
-            }, subcategoryGroup.ToArray());
-        }
-    }
-
     private static IEnumerable<GroupNavigationItemData> GenerateCategoryNavItems(IEnumerable<ToolkitFrontMatter> sampleMetadata)
     {
         var samplesByCategory = sampleMetadata.GroupBy(x => x.Category)
@@ -97,5 +73,4 @@ public static class NavigationViewHelper
     /// <param name="NavItem">A navigation item to contain items in this group.</param>
     /// <param name="SampleMetadata">The samples that belong under <see cref="NavItem"/>.</param>
     private record GroupNavigationItemData(MUXC.NavigationViewItem NavItem, IEnumerable<ToolkitFrontMatter> SampleMetadata);
-
 }

--- a/CommunityToolkit.App.Shared/Pages/Shell.xaml
+++ b/CommunityToolkit.App.Shared/Pages/Shell.xaml
@@ -39,7 +39,8 @@
                              Grid.Row="1"
                              IsBackButtonVisible="Collapsed"
                              IsPaneToggleButtonVisible="False"
-                             ItemInvoked="NavView_ItemInvoked">
+                             ItemInvoked="NavView_ItemInvoked"
+                             PaneDisplayMode="Top">
             <Frame x:Name="NavigationFrame"
                    Navigated="NavigationFrameOnNavigated" />
         </muxc:NavigationView>

--- a/CommunityToolkit.App.Shared/Styles/Buttons.xaml
+++ b/CommunityToolkit.App.Shared/Styles/Buttons.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:animatedvisuals="using:Microsoft.UI.Xaml.Controls.AnimatedVisuals"
                     xmlns:controls="using:Microsoft.UI.Xaml.Controls"
@@ -428,7 +428,7 @@
            TargetType="muxc:NavigationViewItem">
         <Setter Property="FontFamily" Value="XamlAutoFontFamily" />
         <Setter Property="FontSize" Value="12" />
-        <Setter Property="Padding" Value="30,0,0,0" />
+        <Setter Property="Padding" Value="120,0,0,0" />
         <!--<Setter Property="FontWeight" Value="SemiBold" />-->
         <Setter Property="Foreground" Value="{ThemeResource TextFillColorSecondaryBrush}" />
     </Style>
@@ -447,12 +447,12 @@
     </Style>
 
     <DataTemplate x:Key="LabsLabelIconTemplate">
-        <Grid Padding="4,0,4,0"
+        <Grid Padding="4,0,4,1"
               Background="#FFC225"
               CornerRadius="4">
             <TextBlock HorizontalAlignment="Center"
                        VerticalAlignment="Center"
-                       FontSize="12"
+                       FontSize="11"
                        FontWeight="SemiBold"
                        Foreground="Black"
                        Text="LABS" />


### PR DESCRIPTION
This PR introduces the a styling tweak to the LABS tag and sets the DisplayMode to Top for the NavView. Here's why:

Our current layout requires a lot of clicking to find the right object (twice to get to the root samples). When clicking controls, I need to scroll back, click on the expander again, and then dive into the next category. With this PR, that process is faster.

![TopNav](https://github.com/user-attachments/assets/c3d7f954-3120-4c47-83db-3ad6933fe49c)
