### PR TITLE
Remove debug output statements from Get-Changed-Components.ps1

### DIFF
--- a/Get-Changed-Components.ps1
+++ b/Get-Changed-Components.ps1
@@ -47,14 +47,6 @@ $retChangedComponents = -not [string]::IsNullOrWhiteSpace($changedComponentFiles
 #   - Are a fallback to ensure that the script doesn't return an empty list of components.
 $retAllComponents = [string]::IsNullOrWhiteSpace($changedComponentFiles) -or -not [string]::IsNullOrWhiteSpace($otherChanges);
 
-Write-Output "Relevant vars: "
-Write-Output "`$fromSha: $FromSha"
-Write-Output "`$toSha: $ToSha"
-Write-Output "`$changedComponentFiles: $changedComponentFiles"
-Write-Output "`$otherChanges: $otherChanges"
-Write-Output "`$retChangedComponents: $retChangedComponents"
-Write-Output "`$retAllComponents: $retAllComponents"
-
 if ($retAllComponents) {
     return 'all';
 }


### PR DESCRIPTION
Follow up to https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/283 after failures found in https://github.com/CommunityToolkit/Labs-Windows/pull/671. Seems that anything written to stdout is taken as the env variable, including the debug output that was added to help us guard against future issues.  