### PR TITLE
Only include heads for requested MultiTargets if Components that use them were included

### DIFF
--- a/GenerateAllSolution.ps1
+++ b/GenerateAllSolution.ps1
@@ -111,10 +111,45 @@ $projects = [System.Collections.ArrayList]::new()
 # Common/Dependencies for shared infrastructure
 [void]$projects.Add(".\tooling\CommunityToolkit*\*.*proj")
 
-# Deployable sample gallery heads 
+# Individual projects
+if ($Components -eq @('all')) {
+    $Components = @('**')
+}
+
+
+$allUsedMultiTargetPrefs = @()
+
+foreach ($componentName in $Components) {
+    if ($ExcludeComponents -contains $componentName) {
+        continue;
+    }
+    
+    foreach ($componentPath in Get-Item "$PSScriptRoot/../components/$componentName/") {
+        $multiTargetPrefs = & $PSScriptRoot\MultiTarget\Get-MultiTargets.ps1 -component $($componentPath.BaseName)
+
+        $usedMultiTargetPrefs = $multiTargetPrefs.Where({ $MultiTargets.Contains($_) });
+        $shouldReferenceInSolution = $usedMultiTargetPrefs.Count -gt 0
+        
+        if ($shouldReferenceInSolution) {
+            Write-Output "Add component $componentPath to solution";
+            $allUsedMultiTargetPrefs += $usedMultiTargetPrefs
+            
+            [void]$projects.Add(".\components\$($componentPath.BaseName)\src\*.csproj")
+            [void]$projects.Add(".\components\$($componentPath.BaseName)\samples\*.Samples.csproj")
+            [void]$projects.Add(".\components\$($componentPath.BaseName)\tests\*.shproj")
+        } else {
+            Write-Warning "Component $($componentPath.BaseName) doesn't MultiTarget any of $MultiTargets and won't be added to the solution.";
+        }
+    }
+}
+
+# Deployable sample gallery heads
+# Only include heads for requested MultiTargets if components were included that use them.
+# ===
 # TODO: this handles separate project heads, but won't directly handle the unified Skia head from Uno.
 # Once we have that, just do a transform on the csproj filename inside this loop to decide the same csproj for those separate MultiTargets.
-foreach ($multitarget in $MultiTargets) {
+# ===
+foreach ($multitarget in $allUsedMultiTargetPrefs) {
     # capitalize first letter, avoid case sensitivity issues on linux
     $csprojFileNamePartForMultiTarget = $multitarget.substring(0,1).ToUpper() + $multitarget.Substring(1).ToLower()
 
@@ -125,33 +160,6 @@ foreach ($multitarget in $MultiTargets) {
     }
     else {
         Write-Warning "No project head could be found at $path for MultiTarget $multitarget. Skipping."
-    }
-}
-
-# Individual projects
-if ($Components -eq @('all')) {
-    $Components = @('**')
-}
-
-foreach ($componentName in $Components) {
-    if ($ExcludeComponents -contains $componentName) {
-        continue;
-    }
-    
-    foreach ($componentPath in Get-Item "$PSScriptRoot/../components/$componentName/") {
-        $multiTargetPrefs = & $PSScriptRoot\MultiTarget\Get-MultiTargets.ps1 -component $($componentPath.BaseName)
-
-        $shouldReferenceInSolution = $multiTargetPrefs.Where({ $MultiTargets.Contains($_) }).Count -gt 0
-
-        if ($shouldReferenceInSolution) {
-            Write-Output "Add component $componentPath to solution";
-
-            [void]$projects.Add(".\components\$($componentPath.BaseName)\src\*.csproj")
-            [void]$projects.Add(".\components\$($componentPath.BaseName)\samples\*.Samples.csproj")
-            [void]$projects.Add(".\components\$($componentPath.BaseName)\tests\*.shproj")
-        } else {
-            Write-Warning "Component $($componentPath.BaseName) doesn't MultiTarget any of $MultiTargets and won't be added to the solution.";
-        }
     }
 }
 


### PR DESCRIPTION
This PR fixes a regression introduced in https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/281 and https://github.com/CommunityToolkit/Labs-Windows/pull/647

Uncovered in a [CI run](https://github.com/CommunityToolkit/Labs-Windows/actions/runs/15001710983/job/42159081922?pr=674#step:12:1892) for https://github.com/CommunityToolkit/Labs-Windows/pull/674, the WASM build will fail in incremental CI runs where the components changed don't support wasm, such as with MarkdownTextBlock.

The error manifests as ` The name 'ToolkitSampleRegistry' does not exist in the current context`, which happens when no components were found by the source generator, usually because the MultiTarget system correctly prevented the improper import.

The fix is to adjust solution generation so that Gallery heads designed to run a specific MultiTarget are only included in the solution if a component with that MultiTarget was also included. 

This way, if no requested components support the available heads (wasm, uwp, wasdk), those heads aren't included in the generated solution.