### PR TITLE
Update Uno Behaviors to 3.0.3

### DIFF
--- a/ProjectHeads/App.Head.Uno.UI.Dependencies.props
+++ b/ProjectHeads/App.Head.Uno.UI.Dependencies.props
@@ -3,7 +3,7 @@
 <Project>
   <ItemGroup>
     <!--<PackageReference Include="Uno.Microsoft.Toolkit.Uwp.UI.Controls.Markdown" Version="7.1.11" />-->
-    <PackageReference Include="Uno.Microsoft.Xaml.Behaviors.Interactivity" Version="3.0.0-dev.17.g7c09b9114d" />
+    <PackageReference Include="Uno.Microsoft.Xaml.Behaviors.Interactivity" Version="3.0.3" />
   </ItemGroup>
 </Project>
 

--- a/ProjectHeads/App.Head.Uno.WinUI.Dependencies.props
+++ b/ProjectHeads/App.Head.Uno.WinUI.Dependencies.props
@@ -3,7 +3,7 @@
 <Project>
   <ItemGroup>
     <!--<PackageReference Include="Uno.CommunityToolkit.WinUI.UI.Controls.Markdown" Version="7.1.100-dev.15.g12261e2626" />-->
-    <PackageReference Include="Uno.Microsoft.Xaml.Behaviors.Interactivity.WinUI" Version="3.0.0-dev.17.g7c09b9114d" />
+    <PackageReference Include="Uno.Microsoft.Xaml.Behaviors.Interactivity.WinUI" Version="3.0.3" />
     <PackageReference Include="Uno.WinUI.Lottie" Version="5.5.87" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR bumps our dependency on `Uno.Microsoft.Xaml.Behaviors.Interactivity` and `Uno.Microsoft.Xaml.Behaviors.Interactivity.WinUI` to a stable version, removing our dependency on the prerelease version of 3.x originally added alongside UWP .NET 9 support. 