### PR TITLE
Refactor MultiTarget scripts for checking component support

### DIFF
--- a/MultiTarget/Filter-Supported-Components.ps1
+++ b/MultiTarget/Filter-Supported-Components.ps1
@@ -1,0 +1,69 @@
+<#
+.SYNOPSIS
+    Given a list of components, filters them based on their support for the specified MultiTarget TFM(s) and WinUI major version.
+
+.DESCRIPTION
+    This script checks each component to determine if it supports the specified MultiTarget TFM(s) and WinUI major version.
+    It returns a list of components that are supported for the given parameters.
+
+.PARAMETER MultiTargets
+    Specifies the MultiTarget TFM(s) to include for building the components.
+
+.PARAMETER WinUIMajorVersion
+    Specifies the WinUI major version to use when building for Uno. Also decides the package id and dependency variant.
+
+.NOTES
+    Author: Arlo Godfrey
+    Date:   6/6/2025
+#>
+Param (
+    [ValidateSet('all', 'wasm', 'uwp', 'wasdk', 'wpf', 'linuxgtk', 'macos', 'ios', 'android', 'netstandard')]
+    [Alias("mt")]
+    [Parameter(Mandatory=$true)]
+    [string[]]$MultiTargets,
+
+    [Alias("c")]
+    [Parameter(Mandatory=$true)]
+    [string[]]$Components,
+
+    [Alias("winui")]
+    [Parameter(Mandatory=$true)]
+    [int]$WinUIMajorVersion
+)
+
+if ($MultiTargets -eq 'all') {
+    $MultiTargets = @('wasm', 'uwp', 'wasdk', 'wpf', 'linuxgtk', 'macos', 'ios', 'android', 'netstandard')
+}
+
+$supportedComponents = @();
+
+if ($Components -eq @('all')) {
+    $Components = @('**')
+}
+
+foreach ($ComponentName in $Components) {
+    # Find all components source csproj (when wildcard), or find specific component csproj by name.
+    $path = "$PSScriptRoot/../../components/$ComponentName/src/*.csproj"
+    
+    foreach ($componentCsproj in Get-ChildItem -Path $path) {
+        # Get component name from csproj path
+        $componentPath = Get-Item "$componentCsproj/../../"
+        $componentName = $($componentPath.BaseName);
+
+        # Get supported MultiTarget for this component
+        $supportedMultiTargets = & $PSScriptRoot\Get-MultiTargets.ps1 -component $componentName
+        
+        $componentSupportResult = & $PSScriptRoot\Test-Component-Support.ps1 `
+            -RequestedMultiTargets $MultiTargets `
+            -SupportedMultiTargets $supportedMultiTargets `
+            -Component $componentName `
+            -WinUIMajorVersion $WinUIMajorVersion
+
+        if ($componentSupportResult.IsSupported -eq $true) {
+            $supportedComponents += $componentName
+        }
+    }
+}
+
+
+return $supportedComponents;

--- a/MultiTarget/Get-MultiTargets.ps1
+++ b/MultiTarget/Get-MultiTargets.ps1
@@ -50,4 +50,4 @@ if ($null -eq $regex -or $null -eq $regex.Matches -or $null -eq $regex.Matches.G
 }
 
 $multiTargets = $regex.Matches.Groups[1].Value;
-return $multiTargets.Split(';');
+return $multiTargets.Split(';') | Where-Object { $_ -ne '' };

--- a/MultiTarget/Test-Component-Support.ps1
+++ b/MultiTarget/Test-Component-Support.ps1
@@ -18,9 +18,14 @@
     Specifies the WinUI major version to use when building for Uno. Also decides the package id and dependency variant.
 
 .EXAMPLE
-    Build-Toolkit-Components -MultiTargets 'uwp', 'wasm' -DateForVersion '220101' -PreviewVersion 'local' -NupkgOutput 'C:\Output' -BinlogOutput 'C:\Logs' -EnableBinLogs -Components 'MyComponent1', 'MyComponent2' -ExcludeComponents 'MyComponent3' -Release -Verbose
+    Test-Component-Support -RequestedMultiTargets 'uwp', 'wasm' -Component 'MarkdownTextBlock' -WinUIMajorVersion 2
 
-    Builds the 'MyComponent1' and 'MyComponent2' components for the 'uwp' and 'wasm' target frameworks with version '220101' and preview version 'local'. The 'MyComponent3' component will be excluded from building. The .nupkg files will be copied to 'C:\Output' and binlogs will be generated in 'C:\Logs'. The components will be built in Release configuration with detailed msbuild verbosity.
+    Tests if the 'MarkdownTextBlock' component supports the 'uwp' and 'wasm' target frameworks with WinUI 2. Returns an object indicating if the component is supported and the reason if not.
+
+.EXAMPLE
+    Test-Component-Support -SupportedMultiTargets 'uwp', 'wasm', 'wasdk' -RequestedMultiTargets 'all' -Component 'DataTable' -WinUIMajorVersion 3
+
+    Tests if the 'DataTable' component supports all target frameworks with WinUI 3, using the explicitly provided supported MultiTargets instead of retrieving them.
 
 .NOTES
     Author: Arlo Godfrey

--- a/MultiTarget/Test-Component-Support.ps1
+++ b/MultiTarget/Test-Component-Support.ps1
@@ -73,7 +73,7 @@ if ($null -ne $SupportedMultiTargets -and $SupportedMultiTargets.Count -gt 0) {
         Write-Error "Component name must be specified to retrieve supported MultiTargets."
         exit 1
     }
-    $supportedMultiTargets = & $PSScriptRoot\MultiTarget\Get-MultiTargets.ps1 -component $Component
+    $supportedMultiTargets = & $PSScriptRoot\Get-MultiTargets.ps1 -component $Component
 }
 
         

--- a/MultiTarget/Test-Component-Support.ps1
+++ b/MultiTarget/Test-Component-Support.ps1
@@ -106,7 +106,7 @@ foreach ($supportedMultiTarget in $supportedMultiTargets) {
 # If none of the requested targets are supported by the component, we can skip build to save time and avoid errors.
 if (-not $isRequestedTargetSupported) {
     $IsSupported = $false
-    $Reason = "None of the requested MultiTargets '$MultiTargets' are enabled for this component."
+    $Reason = "None of the requested MultiTargets '$RequestedMultiTargets' are enabled for this component."
 }
 
 if (-not $isWinUI0Supported -and $WinUIMajorVersion -eq 0) {

--- a/MultiTarget/Test-Component-Support.ps1
+++ b/MultiTarget/Test-Component-Support.ps1
@@ -1,0 +1,131 @@
+<#
+.SYNOPSIS
+    Tests WinUI support for a specific component and its requested MultiTargets.
+
+.DESCRIPTION
+    This script tests WinUI support for a specific component and its requested MultiTargets. It checks if the requested MultiTargets are supported by the component and if the WinUI version is compatible.
+
+.PARAMETER SupportedMultiTargets
+    Specifies known supported MultiTargets for the given component. Is retrieved if not specified.
+
+.PARAMETER RequestedMultiTargets
+    Specifies the MultiTarget TFM(s) to include for building the components. The default value is 'all'. If not specified, it will use the supported MultiTargets.
+
+.PARAMETER Component
+    Specifies the names of the components to build. Defaults to all components.
+
+.PARAMETER WinUIMajorVersion
+    Specifies the WinUI major version to use when building for Uno. Also decides the package id and dependency variant.
+
+.EXAMPLE
+    Build-Toolkit-Components -MultiTargets 'uwp', 'wasm' -DateForVersion '220101' -PreviewVersion 'local' -NupkgOutput 'C:\Output' -BinlogOutput 'C:\Logs' -EnableBinLogs -Components 'MyComponent1', 'MyComponent2' -ExcludeComponents 'MyComponent3' -Release -Verbose
+
+    Builds the 'MyComponent1' and 'MyComponent2' components for the 'uwp' and 'wasm' target frameworks with version '220101' and preview version 'local'. The 'MyComponent3' component will be excluded from building. The .nupkg files will be copied to 'C:\Output' and binlogs will be generated in 'C:\Logs'. The components will be built in Release configuration with detailed msbuild verbosity.
+
+.NOTES
+    Author: Arlo Godfrey
+    Date:   6/6/2025
+#>
+Param (
+    [ValidateSet('wasm', 'uwp', 'wasdk', 'wpf', 'linuxgtk', 'macos', 'ios', 'android', 'netstandard')]
+    [Alias("smt")]
+    [string[]]$SupportedMultiTargets,
+
+    [ValidateSet('all', 'wasm', 'uwp', 'wasdk', 'wpf', 'linuxgtk', 'macos', 'ios', 'android', 'netstandard')]
+    [Alias("rmt")]
+    [Parameter(Mandatory=$true)]
+    [string[]]$RequestedMultiTargets,
+
+    [Alias("c")]
+    [Parameter(Mandatory=$true)]
+    [string]$Component,
+
+    [Alias("winui")]
+    [Parameter(Mandatory=$true)]
+    [int]$WinUIMajorVersion
+)
+
+if ($RequestedMultiTargets -eq 'all') {
+    $RequestedMultiTargets = @('wasm', 'uwp', 'wasdk', 'wpf', 'linuxgtk', 'macos', 'ios', 'android', 'netstandard')
+}
+
+# List of WinUI-0 (non-WinUI) compatible multitargets
+$WinUI0MultiTargets = @('netstandard')
+
+# List of WinUI-2 compatible multitargets
+$WinUI2MultiTargets = @('uwp', 'wasm', 'wpf', 'linuxgtk', 'macos', 'ios', 'android')
+
+# List of WinUI-3 compatible multitargets
+$WinUI3MultiTargets = @('wasdk', 'wasm', 'wpf', 'linuxgtk', 'macos', 'ios', 'android')
+
+# If WinUI 0 is requested, the component must not support WinUI 2 or WinUI 3 to be built.
+# If WinUI 2 or 3 is requested, the component must have a target that supports WinUI 2 or 3 to be built.
+$isWinUI0Supported = $false
+$isWinUI2Supported = $false
+$isWinUI3Supported = $false
+
+if ($null -ne $SupportedMultiTargets -and $SupportedMultiTargets.Count -gt 0) {
+    # If supported MultiTargets are provided, use them directly
+    $supportedMultiTargets = $SupportedMultiTargets
+} else {
+    # If not provided, retrieve the supported MultiTargets for the component
+    if ($null -eq $Component) {
+        Write-Error "Component name must be specified to retrieve supported MultiTargets."
+        exit 1
+    }
+    $supportedMultiTargets = & $PSScriptRoot\MultiTarget\Get-MultiTargets.ps1 -component $Component
+}
+
+        
+# Flag to check if any of the requested targets are supported by the component
+$isRequestedTargetSupported = $false
+
+foreach ($requestedTarget in $RequestedMultiTargets) {
+    if ($false -eq $isRequestedTargetSupported) {
+        $isRequestedTargetSupported = $requestedTarget -in $supportedMultiTargets
+    }
+}
+
+foreach ($supportedMultiTarget in $supportedMultiTargets) {
+    # Only build components that support WinUI 2
+    if ($false -eq $isWinUI2Supported) {
+        $isWinUI2Supported = $supportedMultiTarget -in $WinUI2MultiTargets;
+    }
+
+    # Only build components that support WinUI 3
+    if ($false -eq $isWinUI3Supported) {
+        $isWinUI3Supported = $supportedMultiTarget -in $WinUI3MultiTargets;
+    }
+
+    # Build components that support neither WinUI 2 nor WinUI 3 (e.g. netstandard only)
+    if ($false -eq $isWinUI0Supported) {
+        $isWinUI0Supported = $supportedMultiTarget -in $WinUI0MultiTargets -and -not ($isWinUI2Supported -or $isWinUI3Supported);
+    }
+}
+
+# If none of the requested targets are supported by the component, we can skip build to save time and avoid errors.
+if (-not $isRequestedTargetSupported) {
+    $IsSupported = $false
+    $Reason = "None of the requested MultiTargets '$MultiTargets' are enabled for this component."
+}
+
+if (-not $isWinUI0Supported -and $WinUIMajorVersion -eq 0) {
+    $IsSupported = $false
+    $Reason = "WinUI is disabled and one of the supported MultiTargets '$supportedMultiTargets' supports WinUI."
+}
+
+if ((-not $isWinUI2Supported -and $WinUIMajorVersion -eq 2) -or (-not $isWinUI3Supported -and $WinUIMajorVersion -eq 3)) {
+    $IsSupported = $false
+    $Reason = "WinUI $WinUIMajorVersion is enabled and not supported by any of the MultiTargets '$supportedMultiTargets'"
+}
+
+if ($null -eq $IsSupported) {
+    # Default to true if no conditions were met
+    $IsSupported = $true
+    $Reason = $null
+}
+
+return [PSCustomObject]@{
+    IsSupported = $IsSupported
+    Reason  = $Reason
+}


### PR DESCRIPTION
This PR:
-  Extracts MultiTarget/WinUI code checks from `Build-Toolkit-Components.ps1` into a dedicated script `Test-Component-Support.ps1`.
- Adds a new script `Filter-Supported-Components.ps1` as a one-liner for filtering (or populating) a list of toolkit components based on whether they support the given WinUI and MultiTarget preferences.
    - This is needed to fix workflow issues with incremental component builds over in Labs, see https://github.com/CommunityToolkit/Labs-Windows/actions/runs/15497274118/job/43639235687#step:14:1