### PR TITLE
Fix output formatting for changed component list

### DIFF
--- a/Get-Changed-Components.ps1
+++ b/Get-Changed-Components.ps1
@@ -54,8 +54,7 @@ if ($retAllComponents) {
 if ($retChangedComponents) {
   $names = $changedComponentFiles | ForEach-Object { ($_ -replace '^components/', '') -replace '/.*$', '' }
   $uniqueNames = $names | Sort-Object -Unique
-  $quotedNames = $uniqueNames | ForEach-Object { "'$_'" }
-  $changedComponentsList = $quotedNames -join ','
+  $changedComponentsList = $uniqueNames -join ','
   return $changedComponentsList
 }
 


### PR DESCRIPTION
Fixes the `Get-Changed-Components.ps1` script to avoid adding unecessary single quotes around items in the output list.

Follow-up to https://github.com/CommunityToolkit/Labs-Windows/pull/682

Should fix the remaining CI issue in https://github.com/CommunityToolkit/Labs-Windows/actions/runs/15547161141/job/43770803845?pr=680