### PR TITLE
Migrate CI to windows-latest-large runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   # This workflow contains a single job called "Xaml-Style-Check"
   Xaml-Style-Check:
-    runs-on: windows-latest
+    runs-on: windows-latest-large
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -89,7 +89,7 @@ jobs:
 
   # Test job to build the project template
   project-template:
-    runs-on: windows-latest
+    runs-on: windows-latest-large
     env:
       HEADS_DIRECTORY: tooling/ProjectHeads
       PROJECT_DIRECTORY: tooling/ProjectTemplate
@@ -139,7 +139,7 @@ jobs:
 
   # Test job to build a single experiment to ensure our changes work for both our main types of solutions at the moment
   new-experiment:
-    runs-on: windows-latest
+    runs-on: windows-latest-large
     
     strategy:
       fail-fast: false # prevent one matrix pipeline from being cancelled if one fails, we want them all to run to completion.


### PR DESCRIPTION
This resolves disk space issues that emerged with GitHub's infrastructure changes, allowing builds to complete successfully with adequate disk space for UWP/WinAppSDK builds.

- Update Xaml-Style-Check job to use windows-latest-large
- Update project-template job to use windows-latest-large
- Update new-experiment job to use windows-latest-large

Addresses the tooling submodule portion of the CI runner migration as documented in the broader infrastructure update initiative.

This same change has been made in these upstream consuming repos:
- https://github.com/CommunityToolkit/Labs-Windows/pull/731
- https://github.com/CommunityToolkit/Windows/pull/729