### PR TITLE
Pin to windows-2022 runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   # This workflow contains a single job called "Xaml-Style-Check"
   Xaml-Style-Check:
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -89,7 +89,7 @@ jobs:
 
   # Test job to build the project template
   project-template:
-    runs-on: windows-latest
+    runs-on: windows-2022
     env:
       HEADS_DIRECTORY: tooling/ProjectHeads
       PROJECT_DIRECTORY: tooling/ProjectTemplate
@@ -139,7 +139,7 @@ jobs:
 
   # Test job to build a single experiment to ensure our changes work for both our main types of solutions at the moment
   new-experiment:
-    runs-on: windows-latest
+    runs-on: windows-2022
     
     strategy:
       fail-fast: false # prevent one matrix pipeline from being cancelled if one fails, we want them all to run to completion.


### PR DESCRIPTION
## Background

On September 30, 2025, GitHub changed the `windows-latest` runner label to point to `windows-2025` (previously `windows-2022`). The Windows Server 2025 runners removed all preinstalled Windows SDKs except the latest version.

This change immediately broke all CI builds across the Windows Community Toolkit repositories. Our builds require two specific Windows SDK versions:
- **SDK 17763** for UWP (TargetFramework)
- **SDK 19041** for WinAppSDK (TargetFramework)

Upgrading these TFM versions would force all consumers to update, so we maintain these specific SDK requirements to preserve backward compatibility.

## Problem

**Current Impact:**
- All CI builds failing with SDK-related errors
- Cannot build or test any toolkit components
- Blocks all development, testing, and release workflows
- Affects both CommunityToolkit/Labs-Windows and CommunityToolkit/Windows repositories

**Root Cause:**
- `windows-latest` now resolves to `windows-2025`
- Windows 2025 runners only include the latest Windows SDK
- Our builds require SDK 17763 (UWP) and SDK 19041 (WinAppSDK)
- These specific SDK versions are no longer present on windows-2025 runners
- Cannot upgrade TFMs without forcing all consumers to update

**Tracked in:** https://github.com/CommunityToolkit/Labs-Windows/issues/741

## Solution

Pin all Windows runner specifications to `windows-2022` to restore SDK availability:

**Changes:**
- `windows-latest` → `windows-2022` (3 jobs affected)
  - Xaml-Style-Check job
  - project-template job
  - new-experiment job

**Strategy:**
1. Test with `windows-2022` to verify if previous D drive disk space issues are resolved
2. If successful, this provides immediate CI restoration
3. If `windows-2022` still has disk space issues, parent repos can use `windows-2022-large` (which may resolve out of disk space errors from missing D drive)

**Jobs Updated:**
1. **Xaml-Style-Check** - Lightweight XAML styling validation
2. **project-template** - Template building and validation
3. **new-experiment** - Experiment generation and testing

**Testing:**
- CI will run on this PR to validate runner compatibility
- Build success confirms SDK availability on windows-2022
- If builds fail with disk space errors, we'll need to escalate runner size
