### PR TITLE
Swapped xBind template ContentControl to ContentPresenter

### DIFF
--- a/ProjectTemplate/src/ProjectTemplateStyle_xBind.xaml
+++ b/ProjectTemplate/src/ProjectTemplateStyle_xBind.xaml
@@ -33,10 +33,10 @@
             <Setter Property="Template">
                 <Setter.Value>
                     <ControlTemplate TargetType="controls:ProjectTemplate_xBind">
-                        <ContentControl x:Name="ContentContainer"
-                                        HorizontalContentAlignment="Stretch"
-                                        VerticalContentAlignment="Stretch">
-                            <ContentControl.ContentTemplate>
+                        <ContentPresenter x:Name="ContentContainer"
+                                          HorizontalContentAlignment="Stretch"
+                                          VerticalContentAlignment="Stretch">
+                            <ContentPresenter.ContentTemplate>
                                 <DataTemplate x:DataType="controls:ProjectTemplate_xBind">
                                     <Grid Padding="{x:Bind ItemPadding}"
                                           PointerEntered="{x:Bind Element_PointerEntered}">
@@ -48,8 +48,8 @@
                                         </StackPanel>
                                     </Grid>
                                 </DataTemplate>
-                            </ContentControl.ContentTemplate>
-                        </ContentControl>
+                            </ContentPresenter.ContentTemplate>
+                        </ContentPresenter>
                     </ControlTemplate>
                 </Setter.Value>
             </Setter>


### PR DESCRIPTION
@Arlodotexe This is in response to our conversation last night on why a `ContentControl` was used instead of a `ContentPresenter` in the x:Bind template.

I tried swapping it out, and it works with no issues.

I also am beginning to remember that the reason we used a `ContentControl` in Strix has something to do with VisualStates or StateTriggers or something like that, none of which is present in this project template.

I also found more info on how the UserControl is different from the `Control` or `ContentControl`. It appears the `UserControl` is basically a `ContentControl` with no templating. Therefore, it has a `Content` property, but its type is `UIElement`, not `object`. 

Anyway, here's a PR that reduces the visual tree depth of the x:Bind template by directly using a `ContentPresenter` in the `ControlTemplate` rather than a `ContentControl` which will simply wrap a `ContentPresenter`.