### PR TITLE
Align TargetPlatformVersion to 10.0.26100.0 for UWP

### DIFF
--- a/MultiTarget/Extra.props
+++ b/MultiTarget/Extra.props
@@ -8,8 +8,7 @@
     -->
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion>$(TargetPlatformMinVersion)</SupportedOSPlatformVersion>
-    <TargetPlatformVersion Condition="'$(MultiTargetPlatformIdentifier)' == 'windows'">10.0.26100.0</TargetPlatformVersion>
-    <TargetPlatformVersion Condition="'$(MultiTargetPlatformIdentifier)' != 'windows'">10.0.19041.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.26100.0</TargetPlatformVersion>
     
     <Platforms>x86;x64;arm64</Platforms>
   </PropertyGroup>


### PR DESCRIPTION
Make sure we're targeting the latest supported Windows SDK across all platforms, it still has min target of 17763 (1809) which is also supported by the tooling, docs: https://developer.microsoft.com/windows/downloads/windows-sdk/