### PR TITLE
Bump uno-check to latest stable version

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "uno.check": {
-      "version": "1.27.4",
+      "version": "1.33.1",
       "commands": [
         "uno-check"
       ]


### PR DESCRIPTION
This PR updates `uno-check` to 1.33.1, the latest stable version published to nuget.org.

Needed for the CI errors encountered in https://github.com/CommunityToolkit/Labs-Windows/pull/760