### PR TITLE
Disable roll-forward to fix spontaneous CI build failure.

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "9.0.101",
-    "rollForward": "latestFeature"
+    "version": "9.0.308",
+    "rollForward": "disable"
   },
   "msbuild-sdks": 
   {


### PR DESCRIPTION
See https://github.com/CommunityToolkit/Windows/actions/runs/21039291527/job/60496336547

Error observed is:
```
     6>CSC : error CS8032: An instance of analyzer Microsoft.CodeAnalysis.UseExplicitTupleName.UseExplicitTupleNameDiagnosticAnalyzer cannot be created from C:\Program Files\dotnet\sdk\9.0.309\Sdks\Microsoft.NET.Sdk\codestyle\cs\Microsoft.CodeAnalysis.CodeStyle.dll : Exception has been thrown by the target of an invocation.. [D:\a\Labs-Windows\Labs-Windows\tooling\CommunityToolkit.Tooling.TestGen\CommunityToolkit.Tooling.TestGen.csproj]
```