### PR TITLE
Initial implementation of the ToolkitSampleButtonAttribute

### DIFF
--- a/CommunityToolkit.App.Shared/Renderers/ToolkitSampleRenderer.xaml
+++ b/CommunityToolkit.App.Shared/Renderers/ToolkitSampleRenderer.xaml
@@ -2,9 +2,11 @@
 <Page x:Class="CommunityToolkit.App.Shared.Renderers.ToolkitSampleRenderer"
       xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
       xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:converters="using:CommunityToolkit.WinUI.Converters"
       xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
       xmlns:local="using:CommunityToolkit.App.Shared"
       xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:metadata="using:CommunityToolkit.Tooling.SampleGen.Metadata"
       xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
       xmlns:not_win="http://uno.ui/not_win"
       xmlns:renderer="using:CommunityToolkit.App.Shared.Renderers"
@@ -13,6 +15,10 @@
       ActualThemeChanged="ToolkitSampleRenderer_ActualThemeChanged"
       Loaded="ToolkitSampleRenderer_Loaded"
       mc:Ignorable="d wasm not_win">
+
+    <Page.Resources>
+        <converters:CollectionVisibilityConverter x:Key="CollectionVisibilityConverter" />
+    </Page.Resources>
 
     <Grid CornerRadius="0">
         <Grid.RowDefinitions>
@@ -49,7 +55,7 @@
                         <AdaptiveTrigger MinWindowWidth="0" />
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
-                        <Setter Target="OptionsPanel.(Grid.Row)" Value="1" />
+                        <Setter Target="OptionsPanel.(Grid.Row)" Value="2" />
                         <Setter Target="OptionsPanel.(Grid.Column)" Value="0" />
                         <Setter Target="OptionsPanel.BorderThickness" Value="0,1,0,0" />
                         <Setter Target="FixedOptionsBar.BorderThickness" Value="0" />
@@ -76,6 +82,7 @@
               BorderThickness="1,1,1,1"
               CornerRadius="8">
             <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
@@ -85,7 +92,32 @@
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
 
+            <ScrollViewer x:Name="CommandsPanel"
+                          Grid.Row="0"
+                          Grid.Column="0"
+                          Padding="8"
+                          Visibility="{x:Bind Metadata.SampleButtons, Mode=OneWay, Converter={StaticResource CollectionVisibilityConverter}}">
+                <ItemsControl x:Name="CommandsControl"
+                              ItemsSource="{x:Bind Metadata.SampleButtons, Mode=OneWay}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate x:DataType="metadata:ToolkitSampleButtonCommand">
+                            <Button Command="{x:Bind (metadata:ToolkitSampleButtonCommand), Mode=OneWay}"
+                                    Content="{x:Bind Title, Mode=OneWay}" />
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                    <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                            <StackPanel HorizontalAlignment="Left"
+                                        VerticalAlignment="Center"
+                                        Orientation="Horizontal"
+                                        Spacing="8" />
+                        </ItemsPanelTemplate>
+                    </ItemsControl.ItemsPanel>
+                </ItemsControl>
+            </ScrollViewer>
+
             <Grid x:Name="OptionsPanel"
+                  Grid.RowSpan="2"
                   Grid.Column="1"
                   VerticalAlignment="Stretch"
                   Background="{ThemeResource LayerFillColorDefaultBrush}"
@@ -178,6 +210,7 @@
             </Grid>
 
             <Grid x:Name="ContentPageHolder"
+                  Grid.Row="1"
                   Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}">
                 <!--  A solidbackground we enable when toggling themes. WinUI uses a lot of translucent brushes and might look weird  -->
                 <Border x:Name="ThemeBG"
@@ -196,7 +229,7 @@
             </Grid>
 
             <muxc:Expander x:Name="SourcecodeExpander"
-                           Grid.Row="2"
+                           Grid.Row="3"
                            Grid.ColumnSpan="3"
                            MinHeight="0"
                            Margin="0,-1,0,0"

--- a/CommunityToolkit.App.Shared/Renderers/ToolkitSampleRenderer.xaml.cs
+++ b/CommunityToolkit.App.Shared/Renderers/ToolkitSampleRenderer.xaml.cs
@@ -181,6 +181,15 @@ public sealed partial class ToolkitSampleRenderer : Page
 
         var sampleControlInstance = (UIElement)Metadata.SampleControlFactory();
 
+        // Bind button commands to the sample instance so they can invoke methods via reflection.
+        if (Metadata.SampleButtons is not null)
+        {
+            foreach (var button in Metadata.SampleButtons)
+            {
+                button.BindToInstance(sampleControlInstance);
+            }
+        }
+
         // Custom control-based sample options.
         if (Metadata.SampleOptionsPaneType is not null && Metadata.SampleOptionsPaneFactory is not null)
         {

--- a/CommunityToolkit.Tooling.SampleGen.Tests/ToolkitSampleGeneratedPaneTests.cs
+++ b/CommunityToolkit.Tooling.SampleGen.Tests/ToolkitSampleGeneratedPaneTests.cs
@@ -101,7 +101,7 @@ public partial class ToolkitSampleGeneratedPaneTests
         {
             public static System.Collections.Generic.Dictionary<string, CommunityToolkit.Tooling.SampleGen.Metadata.ToolkitSampleMetadata> Listing
             { get; } = new() {
-                ["Sample"] = new CommunityToolkit.Tooling.SampleGen.Metadata.ToolkitSampleMetadata("Sample", "Test Sample", "", typeof(MyApp.Sample), () => new MyApp.Sample(), null, null, new CommunityToolkit.Tooling.SampleGen.Metadata.IGeneratedToolkitSampleOptionViewModel[] { new CommunityToolkit.Tooling.SampleGen.Metadata.ToolkitSampleNumericOptionMetadataViewModel(name: "TextSize", initial: 12, min: 8, max: 48, step: 2, showAsNumberBox: false, title: "FontSize") })
+                ["Sample"] = new CommunityToolkit.Tooling.SampleGen.Metadata.ToolkitSampleMetadata("Sample", "Test Sample", "", typeof(MyApp.Sample), () => new MyApp.Sample(), null, null, new CommunityToolkit.Tooling.SampleGen.Metadata.IGeneratedToolkitSampleOptionViewModel[] { new CommunityToolkit.Tooling.SampleGen.Metadata.ToolkitSampleNumericOptionMetadataViewModel(name: "TextSize", initial: 12, min: 8, max: 48, step: 2, showAsNumberBox: false, title: "FontSize") }, null)
             };
         }
         """, "Unexpected code generated");

--- a/CommunityToolkit.Tooling.SampleGen.Tests/ToolkitSampleMetadataTests.Buttons.cs
+++ b/CommunityToolkit.Tooling.SampleGen.Tests/ToolkitSampleMetadataTests.Buttons.cs
@@ -1,0 +1,258 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using CommunityToolkit.Tooling.SampleGen.Diagnostics;
+using CommunityToolkit.Tooling.SampleGen.Tests.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Immutable;
+using System.ComponentModel.DataAnnotations;
+
+namespace CommunityToolkit.Tooling.SampleGen.Tests;
+
+public partial class ToolkitSampleMetadataTests
+{
+    [TestMethod]
+    public void SampleButtonAttributeOnNonSample()
+    {
+        var source = """
+            using System.ComponentModel;
+            using CommunityToolkit.Tooling.SampleGen;
+            using CommunityToolkit.Tooling.SampleGen.Attributes;
+
+            namespace MyApp
+            {
+                public partial class Sample : Windows.UI.Xaml.Controls.UserControl
+                {
+                    [ToolkitSampleButton(Title = "Click Me")]
+                    private void OnButtonClick()
+                    {
+                    }
+                }
+            }
+
+            namespace Windows.UI.Xaml.Controls
+            {
+                public class UserControl { }
+            }
+            """;
+
+        var result = source.RunSourceGenerator<ToolkitSampleMetadataGenerator>(SAMPLE_ASM_NAME);
+
+        result.AssertDiagnosticsAre(DiagnosticDescriptors.SampleButtonAttributeOnNonSample);
+        result.AssertNoCompilationErrors();
+    }
+
+    [TestMethod]
+    public void SampleButtonAttributeValid()
+    {
+        var source = """
+            using System.ComponentModel;
+            using CommunityToolkit.Tooling.SampleGen;
+            using CommunityToolkit.Tooling.SampleGen.Attributes;
+
+            namespace MyApp
+            {
+                [ToolkitSample(id: nameof(Sample), "Test Sample", description: "")]
+                public partial class Sample : Windows.UI.Xaml.Controls.UserControl
+                {
+                    [ToolkitSampleButton(Title = "Click Me")]
+                    private void OnButtonClick()
+                    {
+                    }
+                }
+            }
+
+            namespace Windows.UI.Xaml.Controls
+            {
+                public class UserControl { }
+            }
+            """;
+
+        var result = source.RunSourceGenerator<ToolkitSampleMetadataGenerator>(SAMPLE_ASM_NAME);
+
+        result.AssertDiagnosticsAre(DiagnosticDescriptors.SampleNotReferencedInMarkdown);
+        result.AssertNoCompilationErrors();
+    }
+
+    [TestMethod]
+    public void SampleButtonAttributeMultipleButtons()
+    {
+        var source = """
+            using System.ComponentModel;
+            using CommunityToolkit.Tooling.SampleGen;
+            using CommunityToolkit.Tooling.SampleGen.Attributes;
+
+            namespace MyApp
+            {
+                [ToolkitSample(id: nameof(Sample), "Test Sample", description: "")]
+                public partial class Sample : Windows.UI.Xaml.Controls.UserControl
+                {
+                    [ToolkitSampleButton(Title = "Add Item")]
+                    private void AddItemClick()
+                    {
+                    }
+
+                    [ToolkitSampleButton(Title = "Clear Items")]
+                    private void ClearItemsClick()
+                    {
+                    }
+                }
+            }
+
+            namespace Windows.UI.Xaml.Controls
+            {
+                public class UserControl { }
+            }
+            """;
+
+        var result = source.RunSourceGenerator<ToolkitSampleMetadataGenerator>(SAMPLE_ASM_NAME);
+
+        result.AssertDiagnosticsAre(DiagnosticDescriptors.SampleNotReferencedInMarkdown);
+        result.AssertNoCompilationErrors();
+    }
+
+    [TestMethod]
+    public void SampleButtonCommand_GeneratedRegistryExecutesMethod()
+    {
+        // The sample registry is designed to be declared in the sample project,
+        // and generated in the project head. To test end-to-end execution of the
+        // generated button commands, we replicate this setup, verify the generated
+        // registry source, then execute the same command against a matching instance.
+        var sampleSource = """
+            using System.ComponentModel;
+            using CommunityToolkit.Tooling.SampleGen;
+            using CommunityToolkit.Tooling.SampleGen.Attributes;
+
+            namespace MyApp
+            {
+                [ToolkitSample(id: nameof(Sample), "Test Sample", description: "")]
+                public partial class Sample : Windows.UI.Xaml.Controls.UserControl
+                {
+                    public int Counter { get; set; }
+
+                    public Sample()
+                    {
+                    }
+
+                    [ToolkitSampleButton(Title = "Increment")]
+                    private void IncrementCounter()
+                    {
+                        Counter++;
+                    }
+                }
+            }
+
+            namespace Windows.UI.Xaml.Controls
+            {
+                public class UserControl { }
+            }
+            """;
+
+        // Compile sample project as a metadata reference for the generator
+        var sampleProjectAssembly = sampleSource.ToSyntaxTree()
+            .CreateCompilation("MyApp.Samples")
+            .ToMetadataReference();
+
+        // Create application head that references the sample project
+        var headCompilation = string.Empty
+            .ToSyntaxTree()
+            .CreateCompilation("MyApp.Head")
+            .AddReferences(sampleProjectAssembly);
+
+        // Run source generator to produce the registry
+        var result = headCompilation.RunSourceGenerator<ToolkitSampleMetadataGenerator>();
+
+        result.AssertDiagnosticsAre();
+        result.AssertNoCompilationErrors();
+
+        // Verify the generated registry contains the expected button command
+        var registrySource = result.Compilation.GetFileContentsByName("ToolkitSampleRegistry.g.cs");
+        StringAssert.Contains(registrySource, @"new CommunityToolkit.Tooling.SampleGen.Metadata.ToolkitSampleButtonCommand(""Increment"", ""IncrementCounter"")");
+
+        // Now verify the generated command mechanism works end-to-end
+        // by creating the same command the registry would and binding it to an instance
+        var testInstance = new SampleButtonCommandTestTarget();
+        Assert.AreEqual(0, testInstance.Counter);
+
+        var button = new Metadata.ToolkitSampleButtonCommand("Increment", "IncrementCounter");
+        button.BindToInstance(testInstance);
+
+        Assert.AreEqual("Increment", button.Title);
+        Assert.AreEqual("IncrementCounter", button.MethodName);
+        Assert.IsTrue(button.CanExecute(null!));
+
+        // Execute and verify the counter was incremented
+        button.Execute(null!);
+        Assert.AreEqual(1, testInstance.Counter);
+
+        button.Execute(null!);
+        Assert.AreEqual(2, testInstance.Counter);
+    }
+
+    [TestMethod]
+    public void SampleButtonCommand_AssemblyAttributeBridge()
+    {
+        // Verifies that the sample project emits assembly-level ToolkitSampleButtonDataAttribute
+        // and that the head project can read them to populate button commands in the registry.
+        // This tests the mechanism that bridges private method visibility across PE references.
+        var sampleSource = """
+            using System.ComponentModel;
+            using CommunityToolkit.Tooling.SampleGen;
+            using CommunityToolkit.Tooling.SampleGen.Attributes;
+
+            namespace MyApp
+            {
+                [ToolkitSample(id: nameof(Sample), "Test Sample", description: "")]
+                public partial class Sample : Windows.UI.Xaml.Controls.UserControl
+                {
+                    [ToolkitSampleButton(Title = "Increment")]
+                    private void IncrementCounter()
+                    {
+                    }
+                }
+            }
+
+            namespace Windows.UI.Xaml.Controls
+            {
+                public class UserControl { }
+            }
+            """;
+
+        // Step 1: Run the generator on the sample project to produce assembly-level button attributes
+        var sampleResult = sampleSource.RunSourceGenerator<ToolkitSampleMetadataGenerator>(SAMPLE_ASM_NAME);
+        sampleResult.AssertNoCompilationErrors();
+
+        // Verify the sample project generated the assembly-level button metadata
+        var buttonMetadataSource = sampleResult.Compilation.GetFileContentsByName("ToolkitSampleButtonMetadata.g.cs");
+        StringAssert.Contains(buttonMetadataSource, @"ToolkitSampleButtonDataAttribute(""MyApp.Sample"", ""IncrementCounter"", ""Increment"")");
+
+        // Step 2: Compile the sample project WITH the generated source and create a reference
+        var sampleWithGenerated = sampleResult.Compilation.ToMetadataReference();
+
+        // Step 3: Run the generator on the head project
+        var headCompilation = string.Empty
+            .ToSyntaxTree()
+            .CreateCompilation("MyApp.Head")
+            .AddReferences(sampleWithGenerated);
+
+        var headResult = headCompilation.RunSourceGenerator<ToolkitSampleMetadataGenerator>();
+
+        headResult.AssertDiagnosticsAre();
+        headResult.AssertNoCompilationErrors();
+
+        // Verify the head project's registry includes the button command
+        var registrySource = headResult.Compilation.GetFileContentsByName("ToolkitSampleRegistry.g.cs");
+        StringAssert.Contains(registrySource, @"new CommunityToolkit.Tooling.SampleGen.Metadata.ToolkitSampleButtonCommand(""Increment"", ""IncrementCounter"")");
+    }
+}
+
+/// <summary>
+/// Mirrors the generated sample class structure for testing <see cref="Metadata.ToolkitSampleButtonCommand"/> execution.
+/// </summary>
+internal class SampleButtonCommandTestTarget
+{
+    public int Counter { get; set; }
+
+    private void IncrementCounter() => Counter++;
+}

--- a/CommunityToolkit.Tooling.SampleGen/Attributes/ToolkitSampleButtonAttribute.cs
+++ b/CommunityToolkit.Tooling.SampleGen/Attributes/ToolkitSampleButtonAttribute.cs
@@ -1,0 +1,20 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace CommunityToolkit.Tooling.SampleGen.Attributes;
+
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+public class ToolkitSampleButtonAttribute : Attribute
+{
+    /// <summary>
+    /// The title to display on the button.
+    /// </summary>
+    public string? Title { get; set; }
+
+    /// <summary>
+    /// The name of the method this attribute is attached to.
+    /// Set during source generation.
+    /// </summary>
+    public string? MethodName { get; set; }
+}

--- a/CommunityToolkit.Tooling.SampleGen/Attributes/ToolkitSampleButtonDataAttribute.cs
+++ b/CommunityToolkit.Tooling.SampleGen/Attributes/ToolkitSampleButtonDataAttribute.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+namespace CommunityToolkit.Tooling.SampleGen.Attributes;
+
+/// <summary>
+/// Assembly-level attribute emitted by the source generator in sample projects to carry
+/// <see cref="ToolkitSampleButtonAttribute"/> metadata across the compilation boundary.
+/// Private method attributes are not visible from PE metadata references, so the generator
+/// encodes button data as assembly-level attributes that the head project can read.
+/// </summary>
+[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]
+public class ToolkitSampleButtonDataAttribute : Attribute
+{
+    /// <summary>
+    /// The fully qualified type name of the sample class that contains the button method.
+    /// </summary>
+    public string SampleTypeName { get; }
+
+    /// <summary>
+    /// The name of the method to invoke on the sample instance.
+    /// </summary>
+    public string MethodName { get; }
+
+    /// <summary>
+    /// The title to display on the button.
+    /// </summary>
+    public string Title { get; }
+
+    /// <summary>
+    /// Creates a new instance of <see cref="ToolkitSampleButtonDataAttribute"/>.
+    /// </summary>
+    /// <param name="sampleTypeName">The fully qualified type name of the sample class.</param>
+    /// <param name="methodName">The name of the method to invoke.</param>
+    /// <param name="title">The title to display on the button.</param>
+    public ToolkitSampleButtonDataAttribute(string sampleTypeName, string methodName, string title)
+    {
+        SampleTypeName = sampleTypeName;
+        MethodName = methodName;
+        Title = title;
+    }
+}

--- a/CommunityToolkit.Tooling.SampleGen/Diagnostics/DiagnosticDescriptors.cs
+++ b/CommunityToolkit.Tooling.SampleGen/Diagnostics/DiagnosticDescriptors.cs
@@ -220,4 +220,19 @@ public static class DiagnosticDescriptors
         defaultSeverity: DiagnosticSeverity.Error,
         isEnabledByDefault: true,
         description: "Cannot generate sample as the id is already in use by another sample.");
+
+    /// <summary>
+    /// Gets a <see cref="DiagnosticDescriptor"/> indicating a <see cref="Attributes.ToolkitSampleButtonAttribute"/> that was used on a method in a class that does not use <see cref="Attributes.ToolkitSampleAttribute"/>.
+    /// <para>
+    /// Format: <c>"Cannot generate sample button for type {0} as it does not use ToolkitSampleAttribute"</c>.
+    /// </para>
+    /// </summary>
+    public static readonly DiagnosticDescriptor SampleButtonAttributeOnNonSample = new(
+        id: "TKSMPL0016",
+        title: "Invalid sample button declaration",
+        messageFormat: $"Cannot generate sample button for type {{0}} as it does not use ToolkitSampleAttribute",
+        category: typeof(ToolkitSampleMetadataGenerator).FullName,
+        defaultSeverity: DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "Cannot generate sample button for a type which does not use ToolkitSampleAttribute.");
 }

--- a/CommunityToolkit.Tooling.SampleGen/Metadata/ToolkitSampleButtonCommand.cs
+++ b/CommunityToolkit.Tooling.SampleGen/Metadata/ToolkitSampleButtonCommand.cs
@@ -7,15 +7,48 @@ using System.Windows.Input;
 namespace CommunityToolkit.Tooling.SampleGen.Metadata;
 
 /// <summary>
-/// A command that invokes the provided <see cref="Action"/> when executed.
+/// Represents a sample button that can invoke a method on a sample instance.
+/// Contains the display title and method name, and implements <see cref="ICommand"/> for XAML binding.
 /// </summary>
 public class ToolkitSampleButtonCommand : ICommand
 {
-    private readonly Action _callback;
+    private Action? _callback;
 
-    public ToolkitSampleButtonCommand(Action callback)
+    /// <summary>
+    /// Creates a new instance of <see cref="ToolkitSampleButtonCommand"/>.
+    /// </summary>
+    /// <param name="title">The title to display on the button.</param>
+    /// <param name="methodName">The name of the method to invoke on the sample instance.</param>
+    public ToolkitSampleButtonCommand(string title, string methodName)
     {
-        _callback = callback;
+        Title = title;
+        MethodName = methodName;
+    }
+
+    /// <summary>
+    /// The title to display on the button.
+    /// </summary>
+    public string Title { get; }
+
+    /// <summary>
+    /// The name of the method to invoke on the sample instance.
+    /// </summary>
+    public string MethodName { get; }
+
+    /// <summary>
+    /// Binds this command to a method on the specified sample instance using reflection.
+    /// </summary>
+    /// <param name="instance">The sample control instance containing the target method.</param>
+    public void BindToInstance(object instance)
+    {
+        var method = instance.GetType().GetMethod(MethodName,
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+        if (method != null)
+        {
+            _callback = () => method.Invoke(instance, null);
+        }
+
+        CanExecuteChanged?.Invoke(this, EventArgs.Empty);
     }
 
     /// <inheritdoc />
@@ -26,11 +59,12 @@ public class ToolkitSampleButtonCommand : ICommand
     /// <inheritdoc />
     public bool CanExecute(object parameter)
     {
-        return true;
+        return _callback != null;
     }
+
     /// <inheritdoc />
     public void Execute(object parameter)
     {
-        _callback();
+        _callback?.Invoke();
     }
 }

--- a/CommunityToolkit.Tooling.SampleGen/Metadata/ToolkitSampleMetadata.cs
+++ b/CommunityToolkit.Tooling.SampleGen/Metadata/ToolkitSampleMetadata.cs
@@ -53,6 +53,12 @@ public sealed class ToolkitSampleMetadata
     public IGeneratedToolkitSampleOptionViewModel[]? GeneratedSampleOptions { get; set; }
 
     /// <summary>
+    /// Gets or sets the sample buttons that were declared alongside this sample, if any.
+    /// Contains the button title and method name for each button.
+    /// </summary>
+    public ToolkitSampleButtonCommand[]? SampleButtons { get; set; }
+
+    /// <summary>
     /// Contains the metadata needed to identify and display a toolkit sample.
     /// </summary>
     /// <param name="id">A unique identifier for the sample, across all samples.</param>
@@ -66,6 +72,7 @@ public sealed class ToolkitSampleMetadata
     /// </param>
     /// <param name="sampleOptionsPaneFactory">A factory method that returns a new instance of the sample options control.</param>
     /// <param name="generatedSampleOptions">The generated sample options that were declared alongside this sample, if any.</param>
+    /// <param name="sampleButtons">The sample buttons that were declared alongside this sample, if any.</param>
     public ToolkitSampleMetadata(
         string id,
         string displayName,
@@ -74,7 +81,8 @@ public sealed class ToolkitSampleMetadata
         Func<object> sampleControlFactory,
         Type? sampleOptionsPaneType = null,
         Func<object, object>? sampleOptionsPaneFactory = null,
-        IGeneratedToolkitSampleOptionViewModel[]? generatedSampleOptions = null)
+        IGeneratedToolkitSampleOptionViewModel[]? generatedSampleOptions = null,
+        ToolkitSampleButtonCommand[]? sampleButtons = null)
     {
         Id = id;
         DisplayName = displayName;
@@ -84,5 +92,6 @@ public sealed class ToolkitSampleMetadata
         SampleOptionsPaneType = sampleOptionsPaneType;
         SampleOptionsPaneFactory = sampleOptionsPaneFactory;
         GeneratedSampleOptions = generatedSampleOptions;
+        SampleButtons = sampleButtons;
     }
 }

--- a/CommunityToolkit.Tooling.SampleGen/ToolkitSampleMetadataGenerator.Sample.cs
+++ b/CommunityToolkit.Tooling.SampleGen/ToolkitSampleMetadataGenerator.Sample.cs
@@ -8,6 +8,7 @@ using CommunityToolkit.Tooling.SampleGen.Metadata;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Immutable;
 using System.Linq;
 
 namespace CommunityToolkit.Tooling.SampleGen;
@@ -41,6 +42,33 @@ public partial class ToolkitSampleMetadataGenerator : IIncrementalGenerator
             .Collect();
 
         var assemblyName = context.CompilationProvider.Select((x, _) => x.Assembly.Name);
+
+                // Read assembly-level button metadata from referenced assemblies.
+                // Button attributes are placed on private methods in sample classes, which are not visible
+                // through PE metadata references. To bridge this gap, the sample project's generator phase
+                // emits assembly-level attributes that encode button data. The head project reads these.
+                var assemblyButtonData = context.CompilationProvider
+                    .Select((compilation, _) =>
+                    {
+                        var buttons = ImmutableArray.CreateBuilder<(string SampleTypeName, string MethodName, string Title)>();
+                        foreach (var asm in compilation.SourceModule.ReferencedAssemblySymbols)
+                        {
+                            foreach (var attr in asm.GetAttributes())
+                            {
+                                if (attr.AttributeClass?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) ==
+                                    $"global::{typeof(ToolkitSampleButtonDataAttribute).FullName}" &&
+                                    attr.ConstructorArguments.Length == 3)
+                                {
+                                    buttons.Add((
+                                        (string)(attr.ConstructorArguments[0].Value ?? ""),
+                                        (string)(attr.ConstructorArguments[1].Value ?? ""),
+                                        (string)(attr.ConstructorArguments[2].Value ?? "")
+                                    ));
+                                }
+                            }
+                        }
+                        return buttons.ToImmutable();
+                    });
 
         // Only generate diagnostics (sample projects)
         // Skip creating the registry for symbols in the executing assembly. This would place an incomplete registry in each sample project and cause compiler errors.
@@ -107,9 +135,35 @@ public partial class ToolkitSampleMetadataGenerator : IIncrementalGenerator
                 .Where(static x => x.Item1 is not null)
                 .Collect();
 
+            // Find and reconstruct button attributes from method symbols + the containing type symbol.
+            var buttonAttributes = allAttributeData
+                .Select((x, _) =>
+                {
+                    (ISymbol ContainingType, ISymbol Method, ToolkitSampleButtonAttribute Attribute) item = default;
+
+                    if (x.Item1 is IMethodSymbol methodSymbol &&
+                        x.Item2.TryReconstructAs<ToolkitSampleButtonAttribute>() is ToolkitSampleButtonAttribute buttonAttribute)
+                    {
+                        buttonAttribute.MethodName = methodSymbol.Name;
+
+                        if (x.Item2.TryGetNamedArgument(nameof(ToolkitSampleButtonAttribute.Title), out string? title) && !string.IsNullOrWhiteSpace(title))
+                        {
+                            buttonAttribute.Title = title;
+                        }
+
+                        item = (methodSymbol.ContainingType, x.Item1, buttonAttribute);
+                    }
+
+                    return item;
+                })
+                .Where(static x => x.Attribute is not null)
+                .Collect();
+
             var all = optionsPaneAttributes
                 .Combine(toolkitSampleAttributeData)
                 .Combine(generatedPaneOptions)
+                .Combine(buttonAttributes)
+                .Combine(assemblyButtonData)
                 .Combine(markdownFiles)
                 .Combine(csprojFiles)
                 .Combine(assemblyName);
@@ -117,11 +171,17 @@ public partial class ToolkitSampleMetadataGenerator : IIncrementalGenerator
             // TODO: We can make this static if we could pass in our two boolean values as context, no idea how to do that...
             context.RegisterSourceOutput(all, (ctx, data) =>
             {
-                var (((((optionsPaneAttributes, toolkitSampleAttributes), generatedPaneOptions), markdownFiles), csprojFiles), currentAssembly) = data;
+                var (((((((optionsPaneAttributes, toolkitSampleAttributes), generatedPaneOptions), buttonAttributes), assemblyButtonDataValues), markdownFiles), csprojFiles), currentAssembly) = data;
 
                 var toolkitSampleAttributeData = toolkitSampleAttributes.Where(x => x != default).Distinct();
                 var optionsPaneAttributeData = optionsPaneAttributes.Where(x => x != default).Distinct();
                 var generatedOptionPropertyData = generatedPaneOptions.Where(x => x.Attribute is not null && x.Symbol is not null);
+                var buttonAttributeData = buttonAttributes.Where(x => x.Attribute is not null && x.ContainingType is not null);
+
+                // Assembly-level button metadata from referenced assemblies (bridges the PE visibility gap)
+                var assemblyButtonsByTypeName = assemblyButtonDataValues
+                    .GroupBy(x => x.SampleTypeName)
+                    .ToDictionary(g => g.Key, g => g.Select(x => new ToolkitSampleButtonAttribute { MethodName = x.MethodName, Title = x.Title }));
 
                 var markdownFileData = markdownFiles.Where(x => x != default).Distinct();
                 var csprojFileData = csprojFiles.Where(x => x != default).Distinct();
@@ -150,7 +210,9 @@ public partial class ToolkitSampleMetadataGenerator : IIncrementalGenerator
                                 sample.Attribute.Description,
                                 sample.AttachedQualifiedTypeName,
                                 optionsPaneAttributeData.FirstOrDefault(x => x.Item1?.SampleId == sample.Attribute.Id).Item2?.ToString(),
-                                generatedOptionPropertyData.Where(x => x.Symbol.Equals(sample.Symbol, SymbolEqualityComparer.Default)).Select(x => x.Item2)
+                                generatedOptionPropertyData.Where(x => x.Symbol.Equals(sample.Symbol, SymbolEqualityComparer.Default)).Select(x => x.Item2),
+                                buttonAttributeData.Where(x => x.ContainingType.Equals(sample.Symbol, SymbolEqualityComparer.Default)).Select(x => x.Attribute)
+                                    .Concat(assemblyButtonsByTypeName.TryGetValue(sample.AttachedQualifiedTypeName, out var asmButtons) ? asmButtons : Enumerable.Empty<ToolkitSampleButtonAttribute>())
                             )
                     );
 
@@ -158,8 +220,12 @@ public partial class ToolkitSampleMetadataGenerator : IIncrementalGenerator
 
                 if (isExecutingInSampleProject && !skipDiagnostics)
                 {
-                    ReportSampleDiagnostics(ctx, toolkitSampleAttributeData, optionsPaneAttributeData, generatedOptionPropertyData);
+                    ReportSampleDiagnostics(ctx, toolkitSampleAttributeData, optionsPaneAttributeData, generatedOptionPropertyData, buttonAttributeData);
                     ReportDocumentDiagnostics(ctx, sampleMetadata, markdownFileData, toolkitSampleAttributeData, docFrontMatter);
+
+                    // Emit assembly-level attributes encoding button metadata so the head project
+                    // can read them (private method attributes are invisible through PE references).
+                    GenerateButtonMetadataSource(ctx, buttonAttributeData);
                 }
 
                 if (!isExecutingInSampleProject && !skipRegistry)
@@ -187,11 +253,13 @@ public partial class ToolkitSampleMetadataGenerator : IIncrementalGenerator
     private static void ReportSampleDiagnostics(SourceProductionContext ctx,
                                           IEnumerable<(ToolkitSampleAttribute Attribute, string AttachedQualifiedTypeName, ISymbol Symbol)> toolkitSampleAttributeData,
                                           IEnumerable<(ToolkitSampleOptionsPaneAttribute?, ISymbol)> optionsPaneAttribute,
-                                          IEnumerable<(ISymbol, ToolkitSampleOptionBaseAttribute)> generatedOptionPropertyData)
+                                          IEnumerable<(ISymbol, ToolkitSampleOptionBaseAttribute)> generatedOptionPropertyData,
+                                          IEnumerable<(ISymbol ContainingType, ISymbol Method, ToolkitSampleButtonAttribute Attribute)> buttonAttributeData)
     {
         ReportDiagnosticsForInvalidAttributeUsage(ctx, toolkitSampleAttributeData, optionsPaneAttribute, generatedOptionPropertyData);
         ReportDiagnosticsForLinkedOptionsPane(ctx, toolkitSampleAttributeData, optionsPaneAttribute);
         ReportDiagnosticsGeneratedOptionsPane(ctx, toolkitSampleAttributeData, generatedOptionPropertyData);
+        ReportDiagnosticsForButtonAttributes(ctx, toolkitSampleAttributeData, buttonAttributeData);
     }
 
     private static void ReportDiagnosticsForInvalidAttributeUsage(SourceProductionContext ctx,
@@ -307,8 +375,11 @@ public static class ToolkitSampleRegistry
         var generatedSampleOptionsParam = $"new {typeof(IGeneratedToolkitSampleOptionViewModel).FullName}[] {{ {string.Join(", ", BuildNewGeneratedSampleOptionMetadataSource(metadata).ToArray())} }}";
         var sampleOptionsParam = metadata.SampleOptionsAssemblyQualifiedName is null ? "null" : $"typeof({metadata.SampleOptionsAssemblyQualifiedName})";
         var sampleOptionsPaneFactoryParam = metadata.SampleOptionsAssemblyQualifiedName is null ? "null" : $"x => new {metadata.SampleOptionsAssemblyQualifiedName}(({metadata.SampleAssemblyQualifiedName})x)";
+        var sampleButtonsParam = metadata.GeneratedSampleButtons?.Any() == true
+            ? $"new {typeof(ToolkitSampleButtonCommand).FullName}[] {{ {string.Join(", ", BuildNewGeneratedSampleButtonSource(metadata).ToArray())} }}"
+            : "null";
 
-        return @$"[""{kvp.Key}""] = new {typeof(ToolkitSampleMetadata).FullName}(""{metadata.Id}"", ""{metadata.DisplayName}"", ""{metadata.Description}"", {sampleControlTypeParam}, {sampleControlFactoryParam}, {sampleOptionsParam}, {sampleOptionsPaneFactoryParam}, {generatedSampleOptionsParam})";
+        return @$"[""{kvp.Key}""] = new {typeof(ToolkitSampleMetadata).FullName}(""{metadata.Id}"", ""{metadata.DisplayName}"", ""{metadata.Description}"", {sampleControlTypeParam}, {sampleControlFactoryParam}, {sampleOptionsParam}, {sampleOptionsPaneFactoryParam}, {generatedSampleOptionsParam}, {sampleButtonsParam})";
     }
 
     private static IEnumerable<string> BuildNewGeneratedSampleOptionMetadataSource(ToolkitSampleRecord sample)
@@ -335,6 +406,47 @@ public static class ToolkitSampleRegistry
             {
                 throw new NotSupportedException($"Unsupported or unhandled type {item.GetType()}.");
             }
+        }
+    }
+
+    private static IEnumerable<string> BuildNewGeneratedSampleButtonSource(ToolkitSampleRecord sample)
+    {
+        foreach (var button in sample.GeneratedSampleButtons ?? Enumerable.Empty<ToolkitSampleButtonAttribute>())
+        {
+            yield return $@"new {typeof(ToolkitSampleButtonCommand).FullName}(""{button.Title}"", ""{button.MethodName}"")";
+        }
+    }
+
+    private static void ReportDiagnosticsForButtonAttributes(SourceProductionContext ctx,
+                                                             IEnumerable<(ToolkitSampleAttribute Attribute, string AttachedQualifiedTypeName, ISymbol Symbol)> toolkitSampleAttributeData,
+                                                             IEnumerable<(ISymbol ContainingType, ISymbol Method, ToolkitSampleButtonAttribute Attribute)> buttonAttributeData)
+    {
+        // Check for button attributes on methods where the containing class doesn't have ToolkitSampleAttribute
+        var buttonsWithMissingSampleAttribute = buttonAttributeData.Where(x =>
+            x.ContainingType is INamedTypeSymbol &&
+            !toolkitSampleAttributeData.Any(sample => sample.Symbol.Equals(x.ContainingType, SymbolEqualityComparer.Default)));
+
+        foreach (var item in buttonsWithMissingSampleAttribute)
+            ctx.ReportDiagnostic(Diagnostic.Create(DiagnosticDescriptors.SampleButtonAttributeOnNonSample, item.Method.Locations.FirstOrDefault(), item.ContainingType.ToString()));
+    }
+
+    /// <summary>
+    /// Generates assembly-level attributes that encode button metadata discovered from
+    /// method-level <see cref="ToolkitSampleButtonAttribute"/>s. These attributes are
+    /// compiled into the sample assembly so the head project's generator can read them,
+    /// since private method attributes are not visible through PE metadata references.
+    /// </summary>
+    private static void GenerateButtonMetadataSource(SourceProductionContext ctx,
+                                                     IEnumerable<(ISymbol ContainingType, ISymbol Method, ToolkitSampleButtonAttribute Attribute)> buttonAttributeData)
+    {
+        var lines = buttonAttributeData
+            .Select(b => $@"[assembly: global::{typeof(ToolkitSampleButtonDataAttribute).FullName}(""{b.ContainingType}"", ""{b.Attribute.MethodName}"", ""{b.Attribute.Title}"")]")
+            .ToList();
+
+        if (lines.Count > 0)
+        {
+            ctx.AddSource("ToolkitSampleButtonMetadata.g.cs",
+                "// <auto-generated/>\n" + string.Join("\n", lines));
         }
     }
 

--- a/CommunityToolkit.Tooling.SampleGen/ToolkitSampleRecord.cs
+++ b/CommunityToolkit.Tooling.SampleGen/ToolkitSampleRecord.cs
@@ -22,5 +22,6 @@ public partial class ToolkitSampleMetadataGenerator
         string Description,
         string SampleAssemblyQualifiedName,
         string? SampleOptionsAssemblyQualifiedName,
-        IEnumerable<ToolkitSampleOptionBaseAttribute>? GeneratedSampleOptions = null);
+        IEnumerable<ToolkitSampleOptionBaseAttribute>? GeneratedSampleOptions = null,
+        IEnumerable<ToolkitSampleButtonAttribute>? GeneratedSampleButtons = null);
 }


### PR DESCRIPTION
Fixes #4 

This allows sample dev to easily add attribute to a method on their sample page in order to create a UI command button that executes that code (e.g. adding/removing items from a collection)

Example:
```cs
    [ToolkitSampleButton(Title = "Add 5 Items")]
    private void Add5ItemsClick()
    {
```

Attribute takes a Title like others do for the label of the button. Doesn't support enabling/disabling of button with CanExecute, just execution for MVP.

Creates a separate list of items in the ToolkitSampleMetadata to record the method names. Currently uses reflection to bind to the method at runtime, so we need to investigate if better way... Main challenge is taking method name from registry (even with class instance and such) and binding to the constructed instance of the page's methods...

There may have been some complication/duplication here due to how our generators run in two different contexts...?

Note: Assisted by GitHub Copilot using Claude Opus 4.6