### PR TITLE
Prevent sample renderer from stealing tab focus around the sample

### DIFF
--- a/CommunityToolkit.App.Shared/Renderers/ToolkitSampleRenderer.xaml
+++ b/CommunityToolkit.App.Shared/Renderers/ToolkitSampleRenderer.xaml
@@ -189,6 +189,7 @@
                               VerticalAlignment="Stretch">
                     <ContentControl x:Name="PageControl"
                                     Margin="16"
+                                    IsTabStop="False"
                                     HorizontalContentAlignment="Stretch"
                                     VerticalContentAlignment="Stretch"
                                     Content="{x:Bind SampleControlInstance, Mode=OneWay}" />


### PR DESCRIPTION
Follow-up from https://github.com/CommunityToolkit/Labs-Windows/pull/783

Noticed there was an extra invisible tab stop, hopefully this is the main spot.