### PR TITLE
Upgrade GitHub Actions runner images to windows-2025 and install Windows SDKs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   # This workflow contains a single job called "Xaml-Style-Check"
   Xaml-Style-Check:
-    runs-on: windows-2022
+    runs-on: windows-2025
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -190,6 +190,10 @@ jobs:
           mkdir ./.config
           copy ./tooling/.config/dotnet-tools.json ./.config/dotnet-tools.json
           mkdir ./components
+
+      - name: Install Windows SDKs
+        shell: pwsh
+        run: ./tooling/Install-WindowsSdk.ps1
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v2

--- a/Install-WindowsSdk.ps1
+++ b/Install-WindowsSdk.ps1
@@ -1,0 +1,10 @@
+
+$WinSdkTempDir = "C:\WinSdkTemp\"
+$WinSdkSetupExe = "C:\WinSdkTemp\" + "WinSdkSetup.exe"
+
+mkdir $WinSdkTempDir
+
+$client = [System.Net.WebClient]::new()
+$client.DownloadFile("https://go.microsoft.com/fwlink/p/?linkid=870807", $WinSdkSetupExe)
+
+Start-Process -Wait $WinSdkSetupExe "/features OptionId.UWPCpp /q"


### PR DESCRIPTION
## Background

During the [.NET 10 SDK upgrade work](https://github.com/CommunityToolkit/Labs-Windows/pull/791), CI started requiring the Visual Studio 2026 / MSBuild 18 toolchain.

[Visual Studio 2026 18.0](https://learn.microsoft.com/visualstudio/releases/2026/release-notes#november-update-1800) is the release that added .NET 10 support, but the [`windows-2022` runner image](https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md) only includes Visual Studio 2022 / MSBuild 17.

That showed up in the .NET 10 upgrade CI runs when [`microsoft/setup-msbuild` wasn't able to resolve MSBuild 18](https://github.com/CommunityToolkit/Labs-Windows/blob/e37ec617585872a00dcca554f5f517bfc277762d/.github/workflows/build.yml#L178-L182) on [`windows-2022`](https://github.com/CommunityToolkit/Labs-Windows/blob/e37ec617585872a00dcca554f5f517bfc277762d/.github/workflows/build.yml#L68), alongside the parallel tooling work in [Tooling #309](https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/309).

During the follow-up runner investigation, we confirmed why the workflows had been pinned to `windows-2022` in the first place. GitHub changed [`windows-latest` to resolve to `windows-2025`](https://github.com/CommunityToolkit/Windows/pull/737) on September 30, 2025, and the Windows Server 2025 hosted image no longer included the older Windows SDKs our builds depended on. That broke CI at the time, so the repos were pinned back to `windows-2022` in [Windows #737](https://github.com/CommunityToolkit/Windows/pull/737), [Labs #743](https://github.com/CommunityToolkit/Labs-Windows/pull/743), and [Tooling #296](https://github.com/CommunityToolkit/Tooling-Windows-Submodule/pull/296).

[Labs issue #741](https://github.com/CommunityToolkit/Labs-Windows/issues/741) tracked the original runner-image fallout.

## Problem

During the .NET 10 upgrade, the old mitigation became the new blocker. `windows-2022` still avoids the missing-SDK issue, but it cannot provide the VS2026/MSBuild 18 toolchain required by .NET 10. `windows-2025` provides the required VS2026/MSBuild 18 toolchain, but it reintroduces the missing Windows SDK issue that caused the original runner pin.

During the compatibility review, we also confirmed that changing the Windows target requirements is not the right fix. The shared tooling configuration still preserves older Windows target compatibility, including `TargetPlatformMinVersion` `10.0.17763.0`. Raising those requirements would turn a CI image dependency into a consumer-facing compatibility change.

## Solution

During the tooling update, we brought back the small [`Install-WindowsSdk.ps1`](https://github.com/CommunityToolkit/WindowsCommunityToolkit/blob/c8f76d072df53d3622fb5440d63afb06cb9e7a10/build/Install-WindowsSDK.ps1) script from the 7x Windows Community Toolkit build scripts.

During the workflow update, the CI jobs were moved back to `windows-2025` and a new `Install Windows SDKs` step was added before `microsoft/setup-msbuild`.

That gives CI both sides of the requirement:
- The current hosted image with VS2026/MSBuild 18 for .NET 10
- The explicit Windows SDK installation needed to preserve existing Windows target compatibility.

It also makes the SDK dependency explicit instead of depending on whichever SDK versions happen to be preinstalled on the runner image.

A more polished end-user SDK detection/install flow can be handled separately; this PR is intentionally scoped to unblocking CI on `windows-2025`.
