### PR TITLE
Update .NET SDK to 10.0.401 and build tooling

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "microsoft.visualstudio.slngen.tool": {
-      "version": "12.0.13",
+      "version": "12.0.32",
       "commands": [
         "slngen"
       ]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,11 @@
 # See https://github.com/devcontainers/images/tree/main/src/dotnet for image choices
-FROM mcr.microsoft.com/vscode/devcontainers/dotnet:9.0
+FROM mcr.microsoft.com/devcontainers/dotnet:10.0
+
+# Dev container images can lag behind the SDK version pinned by the repository.
+COPY global.json /tmp/global.json
+RUN curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh \
+    && bash /tmp/dotnet-install.sh --jsonfile /tmp/global.json --install-dir /usr/share/dotnet --no-path \
+    && rm /tmp/dotnet-install.sh /tmp/global.json
 
 # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10
 ARG NODE_VERSION="none"
@@ -10,12 +16,7 @@ RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/
 #     && apt-get -y install --no-install-recommends <your-package-list-here>
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-     && apt-get -y install --no-install-recommends ninja-build
-
-RUN apt-get update && apt-get install -y --no-install-recommends apt-transport-https dirmngr gnupg ca-certificates \
-    && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
-    && echo "deb https://download.mono-project.com/repo/debian stable-buster main" | tee /etc/apt/sources.list.d/mono-official-stable.list \
-    && apt-get update && apt-get -y --no-install-recommends install mono-complete
+     && apt-get -y install --no-install-recommends ninja-build mono-complete
 
 # [Optional] Uncomment this line to install global node packages.
 # RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,10 +4,8 @@
 	"name": "C# (.NET)",
 	"build": {
 		"dockerfile": "Dockerfile",
+		"context": "..",
 		"args": {
-			// Update 'VARIANT' to pick a .NET Core version: 3.1, 5.0, 6.0
-			// Append -bullseye or -focal to pin to an OS version.
-			"VARIANT": "9.0",
 			// Options
 			"NODE_VERSION": "lts/*"
 		}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,8 +94,7 @@ jobs:
       - name: Configure Pagefile
         uses: al-cheb/configure-pagefile-action@v1.4
         with:
-          # Leave room for SDK installation while allowing the pagefile to grow during builds.
-          minimum-size: 8GB
+          minimum-size: 32GB
           maximum-size: 32GB
           disk-root: "C:"
 
@@ -123,10 +122,6 @@ jobs:
         run: |
           copy ./tooling/.github/workflows/config/* ./
           copy ./tooling/global.json ./
-
-      - name: Install Windows SDKs
-        shell: pwsh
-        run: ./tooling/Install-WindowsSdk.ps1
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v2
@@ -167,7 +162,7 @@ jobs:
       - name: Configure Pagefile
         uses: al-cheb/configure-pagefile-action@v1.4
         with:
-          minimum-size: 8GB
+          minimum-size: 32GB
           maximum-size: 32GB
           disk-root: "C:"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   # This workflow contains a single job called "Xaml-Style-Check"
   Xaml-Style-Check:
-    runs-on: windows-2025
+    runs-on: windows-2025-large
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -85,7 +85,7 @@ jobs:
 
   # Test job to build the project template
   project-template:
-    runs-on: windows-2025
+    runs-on: windows-2025-large
     env:
       HEADS_DIRECTORY: tooling/ProjectHeads
       PROJECT_DIRECTORY: tooling/ProjectTemplate
@@ -137,7 +137,7 @@ jobs:
 
   # Test job to build a single experiment to ensure our changes work for both our main types of solutions at the moment
   new-experiment:
-    runs-on: windows-2025
+    runs-on: windows-2025-large
     
     strategy:
       fail-fast: false # prevent one matrix pipeline from being cancelled if one fails, we want them all to run to completion.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
 
   # Test job to build the project template
   project-template:
-    runs-on: windows-2022
+    runs-on: windows-2025-vs2026
     env:
       HEADS_DIRECTORY: tooling/ProjectHeads
       PROJECT_DIRECTORY: tooling/ProjectTemplate
@@ -116,10 +116,16 @@ jobs:
         if: ${{ env.ENABLE_DIAGNOSTICS == 'true' }}
         run: dotnet --info
 
-      - name: Copy props files to root
+      - name: Copy props and SDK configuration to root
         shell: pwsh
         working-directory: ./
-        run: copy ./tooling/.github/workflows/config/* ./
+        run: |
+          copy ./tooling/.github/workflows/config/* ./
+          copy ./tooling/global.json ./
+
+      - name: Install Windows SDKs
+        shell: pwsh
+        run: ./tooling/Install-WindowsSdk.ps1
 
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v2
@@ -135,7 +141,7 @@ jobs:
 
   # Test job to build a single experiment to ensure our changes work for both our main types of solutions at the moment
   new-experiment:
-    runs-on: windows-2022
+    runs-on: windows-2025-vs2026
     
     strategy:
       fail-fast: false # prevent one matrix pipeline from being cancelled if one fails, we want them all to run to completion.
@@ -187,6 +193,7 @@ jobs:
         working-directory: ./
         run: |
           copy ./tooling/.github/workflows/config/* ./
+          copy ./tooling/global.json ./
           mkdir ./.config
           copy ./tooling/.config/dotnet-tools.json ./.config/dotnet-tools.json
           mkdir ./components
@@ -273,6 +280,7 @@ jobs:
         working-directory: ./
         run: |
           copy ./tooling/.github/workflows/config/* ./
+          copy ./tooling/global.json ./
           mkdir ./.config
           copy ./tooling/.config/dotnet-tools.json ./.config/dotnet-tools.json
           mkdir ./components
@@ -309,5 +317,3 @@ jobs:
         with:
           name: linux-logs
           path: ./**/*.*log
-
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
 
   # Test job to build the project template
   project-template:
-    runs-on: windows-2025-vs2026
+    runs-on: windows-2025
     env:
       HEADS_DIRECTORY: tooling/ProjectHeads
       PROJECT_DIRECTORY: tooling/ProjectTemplate
@@ -94,7 +94,8 @@ jobs:
       - name: Configure Pagefile
         uses: al-cheb/configure-pagefile-action@v1.4
         with:
-          minimum-size: 32GB
+          # Leave room for SDK installation while allowing the pagefile to grow during builds.
+          minimum-size: 8GB
           maximum-size: 32GB
           disk-root: "C:"
 
@@ -141,7 +142,7 @@ jobs:
 
   # Test job to build a single experiment to ensure our changes work for both our main types of solutions at the moment
   new-experiment:
-    runs-on: windows-2025-vs2026
+    runs-on: windows-2025
     
     strategy:
       fail-fast: false # prevent one matrix pipeline from being cancelled if one fails, we want them all to run to completion.
@@ -166,7 +167,7 @@ jobs:
       - name: Configure Pagefile
         uses: al-cheb/configure-pagefile-action@v1.4
         with:
-          minimum-size: 32GB
+          minimum-size: 8GB
           maximum-size: 32GB
           disk-root: "C:"
 

--- a/Install-WindowsSdk.ps1
+++ b/Install-WindowsSdk.ps1
@@ -1,14 +1,10 @@
-$ErrorActionPreference = "Stop"
 
 $WinSdkTempDir = "C:\WinSdkTemp\"
 $WinSdkSetupExe = "C:\WinSdkTemp\" + "WinSdkSetup.exe"
 
-New-Item -ItemType Directory -Path $WinSdkTempDir -Force | Out-Null
+mkdir $WinSdkTempDir
 
 $client = [System.Net.WebClient]::new()
-$client.DownloadFile("https://go.microsoft.com/fwlink/?linkid=2311805", $WinSdkSetupExe)
+$client.DownloadFile("https://go.microsoft.com/fwlink/p/?linkid=870807", $WinSdkSetupExe)
 
-$installer = Start-Process -Wait -PassThru $WinSdkSetupExe "/features OptionId.UWPManaged OptionId.UWPCpp /q /norestart"
-if ($installer.ExitCode -notin @(0, 3010)) {
-    throw "Windows SDK 19041 installation failed with exit code $($installer.ExitCode)."
-}
+Start-Process -Wait $WinSdkSetupExe "/features OptionId.UWPCpp /q"

--- a/Install-WindowsSdk.ps1
+++ b/Install-WindowsSdk.ps1
@@ -1,10 +1,14 @@
+$ErrorActionPreference = "Stop"
 
 $WinSdkTempDir = "C:\WinSdkTemp\"
 $WinSdkSetupExe = "C:\WinSdkTemp\" + "WinSdkSetup.exe"
 
-mkdir $WinSdkTempDir
+New-Item -ItemType Directory -Path $WinSdkTempDir -Force | Out-Null
 
 $client = [System.Net.WebClient]::new()
-$client.DownloadFile("https://go.microsoft.com/fwlink/p/?linkid=870807", $WinSdkSetupExe)
+$client.DownloadFile("https://go.microsoft.com/fwlink/?linkid=2311805", $WinSdkSetupExe)
 
-Start-Process -Wait $WinSdkSetupExe "/features OptionId.UWPCpp /q"
+$installer = Start-Process -Wait -PassThru $WinSdkSetupExe "/features OptionId.UWPManaged OptionId.UWPCpp /q /norestart"
+if ($installer.ExitCode -notin @(0, 3010)) {
+    throw "Windows SDK 19041 installation failed with exit code $($installer.ExitCode)."
+}

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -8,7 +8,7 @@ This repository contains the tooling infrastructure for other Community Toolkit 
 ## Build Requirements
 
 - Visual Studio 2026 (UWP & Desktop Workloads for .NET)
-- .NET 9 SDK
+- .NET 10 SDK (version specified in `global.json`)
 - Windows App SDK
 - Windows SDK 26100
 

--- a/ToolkitComponent.SampleProject.props
+++ b/ToolkitComponent.SampleProject.props
@@ -6,7 +6,7 @@
   <!-- Set up the MultiTarget system -->
   <Import Project="$(ToolingDirectory)\MultiTarget\Library.props" />
 
-  <Sdk Condition="'$(IsUwp)' == 'true' AND '$(MultiTargetPlatformIdentifier)' != 'windows'" Name="MSBuild.Sdk.Extras" Version="3.0.23" />
+  <Sdk Condition="'$(IsUwp)' == 'true' AND '$(MultiTargetPlatformIdentifier)' != 'windows'" Name="MSBuild.Sdk.Extras" Version="3.0.44" />
 
   <!-- Import this component's source project -->
   <ItemGroup>

--- a/ToolkitComponent.SourceProject.props
+++ b/ToolkitComponent.SourceProject.props
@@ -18,7 +18,7 @@
     <PackageId Condition="'$(PackageId)' == ''">$(PackageIdPrefix).$(PackageIdVariant).$(ToolkitComponentName)</PackageId>
   </PropertyGroup>
 
-  <Sdk Condition="'$(IsUwp)' == 'true' AND '$(MultiTargetPlatformIdentifier)' != 'windows'" Name="MSBuild.Sdk.Extras" Version="3.0.23" />
+  <Sdk Condition="'$(IsUwp)' == 'true' AND '$(MultiTargetPlatformIdentifier)' != 'windows'" Name="MSBuild.Sdk.Extras" Version="3.0.44" />
 
   <PropertyGroup>
     <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>

--- a/global.json
+++ b/global.json
@@ -1,10 +1,10 @@
 {
   "sdk": {
-    "version": "9.0.310",
+    "version": "10.0.401",
     "rollForward": "latestFeature"
   },
   "msbuild-sdks": 
   {
-    "MSBuild.Sdk.Extras":"3.0.23"
+    "MSBuild.Sdk.Extras":"3.0.44"
   }
 }


### PR DESCRIPTION
## Summary

- Update the .NET SDK from 9.0.310 to **10.0.401**, retaining the existing target frameworks and SDK roll-forward policy.
- Update all MSBuild.Sdk.Extras pins from 3.0.23 to **3.0.44** and Microsoft.VisualStudio.SlnGen.Tool from 12.0.13 to **12.0.32**.
- Use `windows-2025-large` for all Windows CI jobs to provide additional disk space, and copy `global.json` into generated consumer workspaces.
- Align the development container and documented prerequisites with .NET 10. Install the SDK specified by `global.json` in the container because published base images can lag behind SDK servicing releases.

## Integration

Rebased onto `main` after #316 merged. The result preserves its Uno.Check 1.34.1 update, Windows SDK 26100 target frameworks and build requirements, and UWP/WinAppSDK configuration fixes. This PR introduces no Windows SDK installation or pagefile configuration changes.

The requested commit `5e06a74f50b2bc5ca2cba5f4994998fc0d89edc9` from #309 is retained as `330998f`, preserving its original author. It is an empty cherry-pick because its SlnGen update was already included in this PR.

## Validation

- Rebased tooling solution Release build: passed, with zero warnings and errors.
- Rebased source-generator tests: **46 passed**.
- SlnGen 12.0.32 solution generation and the generated solution's Release build were previously validated successfully.
- Checked the combined workflow, SDK/tool pins, README requirements, and preservation of the upstream multitargeting changes.
- Validated that the larger-runner follow-up changes only the three Windows runner labels; Linux jobs and all other workflow configuration remain unchanged.
- Both runner-label review threads are resolved.

CI will validate the native template and experiment matrix on the larger Windows runners. A full development-container build was not run locally because no container engine is available.